### PR TITLE
Add induction kernels for a 2D singular irrotational vortex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,8 @@ uuid = "6ac606dd-6b54-421d-8b39-236b88ac3fdc"
 authors = ["Carlos Fernando Baptista <cfd.baptista@gmail.com>"]
 version = "0.1.0-DEV"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1.9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,7 @@ makedocs(;
     format=Documenter.HTML(;
         canonical="https://CFBaptista.github.io/VEM.jl/stable/", assets=String[]
     ),
-    pages=["Home" => "index.md"],
+    pages=["Home" => "index.md", "API" => "pages/api.md"],
 )
 
 deploydocs(; repo="github.com/CFBaptista/VEM.jl", push_preview=true)

--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -1,0 +1,10 @@
+# API
+
+## Docstrings
+
+```@index
+Pages = ["api.md"]
+```
+```@autodocs
+Modules = [VEM]
+```

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -4,5 +4,6 @@ using LinearAlgebra
 
 include("singular_vortex_particle.jl")
 export compute_velocity
+export compute_velocity_gradient
 
 end

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -1,3 +1,8 @@
 module VEM
 
+using LinearAlgebra
+
+include("singular_vortex_particle.jl")
+export compute_velocity
+
 end

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -5,5 +5,6 @@ using LinearAlgebra
 include("singular_vortex_particle.jl")
 export compute_velocity
 export compute_velocity_gradient
+export compute_vorticity
 
 end

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -6,5 +6,6 @@ include("singular_vortex_particle.jl")
 export compute_velocity
 export compute_velocity_gradient
 export compute_vorticity
+export compute_vorticity_gradient
 
 end

--- a/src/singular_vortex_particle.jl
+++ b/src/singular_vortex_particle.jl
@@ -18,6 +18,11 @@ end
 
 function compute_velocity_gradient(circulation, source, target)
     r = target - source
-    return circulation / (dot(r, r)^2 * pi * 2) *
-           [r[1]*r[2] -r[1]^2+r[2]^2; -r[1]^2+r[2]^2 -r[1]*r[2]]
+    rx, ry = r
+    return circulation / (dot(r, r)^2 * pi * 2) * [rx*ry -rx^2+ry^2; -rx^2+ry^2 -rx*ry]
+end
+
+function compute_vorticity(circulation, source, target)
+    r = target - source
+    return zero(circulation) / dot(r, r)
 end

--- a/src/singular_vortex_particle.jl
+++ b/src/singular_vortex_particle.jl
@@ -20,7 +20,7 @@ A counter-clockwise `circulation` is considered positive.
 See also [`compute_velocity_gradient`](@ref), [`compute_vorticity`](@ref), [`compute_vorticity_gradient`](@ref).
 
 # Examples
-```
+```jldoctest
 julia> circulation = 1.0
 1.0
 
@@ -56,7 +56,7 @@ A counter-clockwise `circulation` is considered positive.
 See also [`compute_velocity`](@ref), [`compute_vorticity`](@ref), [`compute_vorticity_gradient`](@ref).
 
 # Examples
-```
+```jldoctest
 julia> circulation = 1.0
 1.0
 
@@ -92,7 +92,7 @@ A counter-clockwise `circulation` is considered positive.
 See also [`compute_velocity`](@ref), [`compute_velocity_gradient`](@ref), [`compute_vorticity_gradient`](@ref).
 
 # Examples
-```
+```jldoctest
 julia> circulation = 1.0
 1.0
 
@@ -125,7 +125,7 @@ A counter-clockwise `circulation` is considered positive.
 See also [`compute_velocity`](@ref), [`compute_velocity_gradient`](@ref), [`compute_vorticity`](@ref).
 
 # Examples
-```
+```jldoctest
 julia> circulation = 1.0
 1.0
 

--- a/src/singular_vortex_particle.jl
+++ b/src/singular_vortex_particle.jl
@@ -26,3 +26,8 @@ function compute_vorticity(circulation, source, target)
     r = target - source
     return zero(circulation) / dot(r, r)
 end
+
+function compute_vorticity_gradient(circulation, source, target)
+    r = target - source
+    return fill(zero(circulation), (2, 2)) / dot(r, r)
+end

--- a/src/singular_vortex_particle.jl
+++ b/src/singular_vortex_particle.jl
@@ -1,0 +1,17 @@
+function cross_2d(number::Number, vector::AbstractVector{<:Number})
+    if length(vector) != 2
+        throw(
+            DimensionMismatch(
+                "cross product in 2D between a perpendicular-to-plane vector (represented by a scalar) and an in-plane vector is only defined for an in-plane vector of length 2",
+            ),
+        )
+    end
+    return [-number * vector[2], number * vector[1]]
+end
+cross_2d(vector, number) = -cross_2d(number, vector)
+
+function compute_velocity(circulation, source, target)
+    r = target - source
+    v = cross_2d(circulation, r) / (dot(r, r) * pi * 2)
+    return v
+end

--- a/src/singular_vortex_particle.jl
+++ b/src/singular_vortex_particle.jl
@@ -15,3 +15,9 @@ function compute_velocity(circulation, source, target)
     v = cross_2d(circulation, r) / (dot(r, r) * pi * 2)
     return v
 end
+
+function compute_velocity_gradient(circulation, source, target)
+    r = target - source
+    return circulation / (dot(r, r)^2 * pi * 2) *
+           [r[1]*r[2] -r[1]^2+r[2]^2; -r[1]^2+r[2]^2 -r[1]*r[2]]
+end

--- a/src/singular_vortex_particle.jl
+++ b/src/singular_vortex_particle.jl
@@ -10,23 +10,141 @@ function cross_2d(number::Number, vector::AbstractVector{<:Number})
 end
 cross_2d(vector, number) = -cross_2d(number, vector)
 
+"""
+    compute_velocity(circulation, source, target)
+
+Compute the velocity induced at `target` by a 2D singular irrotational vortex located at `source`.
+
+A counter-clockwise `circulation` is considered positive.
+
+See also [`compute_velocity_gradient`](@ref), [`compute_vorticity`](@ref), [`compute_vorticity_gradient`](@ref).
+
+# Examples
+```
+julia> circulation = 1.0
+1.0
+
+julia> source = [0.0, 0.0]
+2-element Vector{Float64}:
+ 0.0
+ 0.0
+
+julia> target = [1.0, 0.0]
+2-element Vector{Float64}:
+ 1.0
+ 0.0
+
+julia> compute_velocity(circulation, source, target)
+2-element Vector{Float64}:
+ -0.0
+  0.15915494309189535
+```
+"""
 function compute_velocity(circulation, source, target)
     r = target - source
     v = cross_2d(circulation, r) / (dot(r, r) * pi * 2)
     return v
 end
 
+"""
+    compute_velocity_gradient(circulation, source, target)
+
+Compute the velocity gradient induced at `target` by a 2D singular irrotational vortex located at `source`.
+
+A counter-clockwise `circulation` is considered positive.
+
+See also [`compute_velocity`](@ref), [`compute_vorticity`](@ref), [`compute_vorticity_gradient`](@ref).
+
+# Examples
+```
+julia> circulation = 1.0
+1.0
+
+julia> source = [0.0, 0.0]
+2-element Vector{Float64}:
+ 0.0
+ 0.0
+
+julia> target = [1.0, 0.0]
+2-element Vector{Float64}:
+ 1.0
+ 0.0
+
+julia> compute_velocity_gradient(circulation, source, target)
+2×2 Matrix{Float64}:
+  0.0       -0.159155
+ -0.159155  -0.0
+```
+"""
 function compute_velocity_gradient(circulation, source, target)
     r = target - source
     rx, ry = r
     return circulation / (dot(r, r)^2 * pi * 2) * [rx*ry -rx^2+ry^2; -rx^2+ry^2 -rx*ry]
 end
 
+"""
+    compute_vorticity(circulation, source, target)
+
+Compute the vorticity induced at `target` by a 2D singular irrotational vortex located at `source`.
+
+A counter-clockwise `circulation` is considered positive.
+
+See also [`compute_velocity`](@ref), [`compute_velocity_gradient`](@ref), [`compute_vorticity_gradient`](@ref).
+
+# Examples
+```
+julia> circulation = 1.0
+1.0
+
+julia> source = [0.0, 0.0]
+2-element Vector{Float64}:
+ 0.0
+ 0.0
+
+julia> target = [1.0, 0.0]
+2-element Vector{Float64}:
+ 1.0
+ 0.0
+
+julia> compute_vorticity(circulation, source, target)
+0.0
+```
+"""
 function compute_vorticity(circulation, source, target)
     r = target - source
     return zero(circulation) / dot(r, r)
 end
 
+"""
+    compute_vorticity_gradient(circulation, source, target)
+
+Compute the vorticity gradient induced at `target` by a 2D singular irrotational vortex located at `source`.
+
+A counter-clockwise `circulation` is considered positive.
+
+See also [`compute_velocity`](@ref), [`compute_velocity_gradient`](@ref), [`compute_vorticity`](@ref).
+
+# Examples
+```
+julia> circulation = 1.0
+1.0
+
+julia> source = [0.0, 0.0]
+2-element Vector{Float64}:
+ 0.0
+ 0.0
+
+julia> target = [1.0, 0.0]
+2-element Vector{Float64}:
+ 1.0
+ 0.0
+
+julia> compute_vorticity_gradient(circulation, source, target)
+2×2 Matrix{Float64}:
+ 0.0  0.0
+ 0.0  0.0
+```
+"""
 function compute_vorticity_gradient(circulation, source, target)
     r = target - source
     return fill(zero(circulation), (2, 2)) / dot(r, r)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,6 +1,4 @@
-using Test
 using Aqua
+using VEM
 
-@testset "Code quality (Aqua.jl)" begin
-    Aqua.test_all(VEM)
-end
+Aqua.test_all(VEM)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 using SafeTestsets
 
 @time @safetestset "Code quality (Aqua.jl)" include("aqua.jl")
+@time @safetestset "Singular vortex particle" include("singular_vortex_particle.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,3 @@
-using VEM
-using Test
+using SafeTestsets
 
-@testset "VEM.jl" begin
-    include("aqua.jl")
-end
+@time @safetestset "Code quality (Aqua.jl)" include("aqua.jl")

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -231,7 +231,7 @@ end
 
             # ---- THEN ----
             @test velocity_gradient[2, 1] ≈ velocity_gradient[1, 2]
-            @test isapprox(velocity_gradient[2, 1], 0, atol=1e-12)
+            @test isapprox(velocity_gradient[2, 1], 0; atol=1e-12)
         end
 
         @testset "GivenAbsHorizontalDistanceLargerThanAbsVerticalDistance_WhenComputeVelocityGradient_ThenOffDiagonalVelocityGradientsAreNegative" begin
@@ -395,6 +395,66 @@ end
                 @test Core.Compiler.return_type(
                     compute_velocity_gradient, Tuple{ctype,stype,ttype}
                 ) == Matrix{promote_type(ctype, eltype(stype), eltype(ttype))}
+            end
+        end
+    end
+end
+
+@testset "Vorticity" begin
+    @testset "Singularity" begin
+        @testset "GivenCirculationUnequalToZeroAndSourceUnequalToTarget_WhenComputeVorticity_ThenZeroVorticity" begin
+            # ---- GIVEN ----
+            circulation = 1 / pi
+            source = [3 / pi, 5 / pi]
+            target = [7 / pi, 11 / pi]
+
+            # ---- WHEN ----
+            vorticity = compute_vorticity(circulation, source, target)
+
+            # ---- THEN ----
+            @test isapprox(vorticity, 0; atol=1e-12)
+        end
+
+        @testset "GivenSourceEqualsTarget_WhenComputeVorticity_ThenVorticityEqualsNaN" begin
+            # ---- GIVEN ----
+            circulation = 1 / 13
+            source = [0.3, 0.7]
+            target = source
+
+            # ---- WHEN ----
+            vorticity = compute_vorticity(circulation, source, target)
+
+            # ---- THEN ----
+            @test isnan(vorticity)
+        end
+    end
+
+    @testset "Return type" begin
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVorticity_ThenReturnTypeIsConcrete" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test isconcretetype(
+                    Core.Compiler.return_type(compute_vorticity, Tuple{ctype,stype,ttype})
+                )
+            end
+        end
+
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVorticity_ThenReturnTypeEqualsPromoteType" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test Core.Compiler.return_type(
+                    compute_vorticity, Tuple{ctype,stype,ttype}
+                ) == promote_type(ctype, eltype(stype), eltype(ttype))
             end
         end
     end

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -335,7 +335,9 @@ end
             velocity_gradient = compute_velocity_gradient(circulation, source, target)
 
             # ---- THEN ----
-            @test isapprox(dot(velocity_gradient[:, 1], velocity_gradient[:, 2]), 0; atol=1e-12)
+            @test isapprox(
+                dot(velocity_gradient[:, 1], velocity_gradient[:, 2]), 0; atol=1e-12
+            )
         end
 
         @testset "GivenUnitCirculationUnitHorizontalDistanceAndUnitVerticalDistance_WhenComputeVelocityGradient_ThenAbsDiagonalEqualReciprocalOfEightPi" begin

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -63,33 +63,19 @@ using VEM
         end
     end
 
-    @testset "Singularity" begin
-        @testset "GivenSourceEqualsTarget_WhenComputeVelocity_ThenVelocityEqualsNaN" begin
+    @testset "Orientation" begin
+        @testset "GivenPositveHorizontalDistanceAndZeroVerticalDistance_WhenComputeVelocity_ThenZeroHorizontalVelocityAndPositveVerticalVelocity" begin
             # ---- GIVEN ----
-            circulation = 1 / 13
-            source = [0.3, 0.7]
-            target = source
+            circulation = 1.0
+            source = [3 / 7, 11 / 13]
+            target = source + [3, 0]
 
             # ---- WHEN ----
             velocity = compute_velocity(circulation, source, target)
 
             # ---- THEN ----
-            @test all(x -> isnan(x), velocity)
-        end
-    end
-
-    @testset "Orthogonality" begin
-        @testset "GivenCirculationSourceAndTarget_WhenComputeVelocity_ThenVelocityPerpendicularToDistance" begin
-            # ---- GIVEN ----
-            circulation = 1 / 17
-            source = [0.7, 1.1]
-            target = [1.3, 2.3]
-
-            # ---- WHEN ----
-            velocity = compute_velocity(circulation, source, target)
-
-            # ---- THEN ----
-            @test dot(target, velocity) ≈ dot(source, velocity)
+            @test isapprox(velocity[1], 0; atol=1e-12)
+            @test velocity[2] > 0
         end
     end
 
@@ -136,6 +122,36 @@ using VEM
         end
     end
 
+    @testset "Orthogonality" begin
+        @testset "GivenCirculationSourceAndTarget_WhenComputeVelocity_ThenVelocityPerpendicularToDistance" begin
+            # ---- GIVEN ----
+            circulation = 1 / 17
+            source = [0.7, 1.1]
+            target = [1.3, 2.3]
+
+            # ---- WHEN ----
+            velocity = compute_velocity(circulation, source, target)
+
+            # ---- THEN ----
+            @test dot(target, velocity) ≈ dot(source, velocity)
+        end
+    end
+
+    @testset "Singularity" begin
+        @testset "GivenSourceEqualsTarget_WhenComputeVelocity_ThenVelocityEqualsNaN" begin
+            # ---- GIVEN ----
+            circulation = 1 / 13
+            source = [0.3, 0.7]
+            target = source
+
+            # ---- WHEN ----
+            velocity = compute_velocity(circulation, source, target)
+
+            # ---- THEN ----
+            @test all(x -> isnan(x), velocity)
+        end
+    end
+
     @testset "Return type" begin
         @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeIsConcrete" begin
             # ---- GIVEN ----
@@ -169,6 +185,28 @@ end
 
 @testset "Velocity gradient" begin
     @testset "Symmetries" begin
+        @testset "GivenTranslationOfOrigin_WhenComputeVelocityGradient_ThenSameVelocityGradient" begin
+            # ---- GIVEN ----
+            circulation = 1 / 3
+            source = [0.3, 0.5]
+            target = [0.7, 1.1]
+
+            translation = [1.0, 1.0]
+            translated_source = source - translation
+            translated_target = target - translation
+
+            # ---- WHEN ----
+            velocity_gradient_without_translation = compute_velocity_gradient(
+                circulation, source, target
+            )
+            velocity_gradient_with_translation = compute_velocity_gradient(
+                circulation, translated_source, translated_target
+            )
+
+            # ---- THEN ----
+            @test velocity_gradient_without_translation ≈ velocity_gradient_with_translation
+        end
+
         @testset "GivenCirculationSourceAndTarget_WhenComputeVelocityGradient_ThenSymmetricVelocityGradient" begin
             # ---- GIVEN ----
             circulation = 5 / 7

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -2,164 +2,362 @@ using LinearAlgebra
 using Test
 using VEM
 
-@testset "Symmetries" begin
-    @testset "GivenTranslationOfOrigin_WhenComputeVelocity_ThenSameVelocity" begin
-        # ---- GIVEN ----
-        circulation = 1 / 3
-        source = [0.3, 0.5]
-        target = [0.7, 1.1]
+@testset "Velocity" begin
+    @testset "Symmetries" begin
+        @testset "GivenTranslationOfOrigin_WhenComputeVelocity_ThenSameVelocity" begin
+            # ---- GIVEN ----
+            circulation = 1 / 3
+            source = [0.3, 0.5]
+            target = [0.7, 1.1]
 
-        translation = [1.0, 1.0]
-        translated_source = source - translation
-        translated_target = target - translation
+            translation = [1.0, 1.0]
+            translated_source = source - translation
+            translated_target = target - translation
 
-        # ---- WHEN ----
-        velocity_without_translation = compute_velocity(circulation, source, target)
-        velocity_with_translation = compute_velocity(
-            circulation, translated_source, translated_target
-        )
-
-        # ---- THEN ----
-        @test velocity_without_translation ≈ velocity_with_translation
-    end
-
-    @testset "GivenRotationOfOrigin_WhenComputeVelocity_ThenSameSpeed" begin
-        # ---- GIVEN ----
-        circulation = 1 / 7
-        source = [0.5, 0.7]
-        target = [1.1, 1.7]
-
-        rotation_angle = 30.0
-        rotation_matrix = [
-            cosd(-rotation_angle) -sind(-rotation_angle)
-            sind(-rotation_angle) cosd(-rotation_angle)
-        ]
-        rotated_source = rotation_matrix * source
-        rotated_target = rotation_matrix * target
-
-        # ---- WHEN ----
-        velocity_without_rotation = compute_velocity(circulation, source, target)
-        velocity_with_rotation = compute_velocity(
-            circulation, rotated_source, rotated_target
-        )
-
-        # ---- THEN ----
-        @test norm(velocity_without_rotation) ≈ norm(velocity_with_rotation)
-    end
-
-    @testset "GivenSwitchSourceAndTarget_WhenComputeVelocity_ThenOppositeVelocity" begin
-        # ---- GIVEN ----
-        circulation = 1 / 11
-        source = [0.7, 1.1]
-        target = [1.3, 2.3]
-
-        # ---- WHEN ----
-        velocity_without_switch = compute_velocity(circulation, source, target)
-        velocity_with_switch = compute_velocity(circulation, target, source)
-
-        # ---- THEN ----
-        @test velocity_without_switch ≈ -velocity_with_switch
-    end
-end
-
-@testset "Singularity" begin
-    @testset "GivenSourceEqualsTarget_WhenComputeVelocity_ThenVelocityEqualsNaN" begin
-        # ---- GIVEN ----
-        circulation = 1 / 13
-        source = [0.3, 0.7]
-        target = source
-
-        # ---- WHEN ----
-        velocity = compute_velocity(circulation, source, target)
-
-        # ---- THEN ----
-        @test all(x -> isnan(x), velocity)
-    end
-end
-
-@testset "Orthogonality" begin
-    @testset "GivenCirculationSourceAndTarget_WhenComputeVelocity_ThenVelocityPerpendicularToDistance" begin
-        # ---- GIVEN ----
-        circulation = 1 / 17
-        source = [0.7, 1.1]
-        target = [1.3, 2.3]
-
-        # ---- WHEN ----
-        velocity = compute_velocity(circulation, source, target)
-
-        # ---- THEN ----
-        @test dot(target, velocity) ≈ dot(source, velocity)
-    end
-end
-
-@testset "Proportionality" begin
-    @testset "GivenDoubleCirculation_WhenComputeVelocity_ThenDoubleVelocity" begin
-        # ---- GIVEN ----
-        circulation = 3 / 7
-        source = [1.3, 1.7]
-        target = [2.3, 2.9]
-
-        # ---- WHEN ----
-        velocity_single_circulation = compute_velocity(circulation, source, target)
-        velocity_double_circulation = compute_velocity(2 * circulation, source, target)
-
-        # ---- THEN ----
-        @test velocity_double_circulation ≈ 2 * velocity_single_circulation
-    end
-
-    @testset "GivenDoubleDistance_WhenComputeVelocity_ThenHalfVelocity" begin
-        # ---- GIVEN ----
-        circulation = 3 / 11
-        source = [0.3, 0.7]
-        target = [1.3, 2.3]
-
-        # ---- WHEN ----
-        velocity_single_distance = compute_velocity(circulation, source, target)
-        velocity_double_distance = compute_velocity(circulation, 2 * source, 2 * target)
-
-        # ---- THEN ----
-        @test velocity_double_distance ≈ 0.5 * velocity_single_distance
-    end
-
-    @testset "GivenUnitCirculationAndUnitDistance_WhenComputeVelocity_ThenSpeedEqualsReciprocalOfTwoPi" begin
-        # ---- GIVEN ----
-        circulation = 1.0
-        source = [3 / 7, 11 / 13]
-        target = source + [0.8, 0.6]
-
-        # ---- WHEN ----
-        velocity = compute_velocity(circulation, source, target)
-
-        # ---- THEN ----
-        @test norm(velocity) ≈ 1 / (2 * pi)
-    end
-end
-
-@testset "Return type" begin
-    @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeIsConcrete" begin
-        # ---- GIVEN ----
-        circulation_types = (Float16, Float32, Float64)
-        source_types = (Vector{x} for x in circulation_types)
-        target_types = (Vector{x} for x in circulation_types)
-
-        # ---- WHEN ---- / ---- THEN ----
-        for ctype in circulation_types, stype in source_types, ttype in target_types
-            @test isconcretetype(
-                Core.Compiler.return_type(compute_velocity, Tuple{ctype,stype,ttype})
+            # ---- WHEN ----
+            velocity_without_translation = compute_velocity(circulation, source, target)
+            velocity_with_translation = compute_velocity(
+                circulation, translated_source, translated_target
             )
+
+            # ---- THEN ----
+            @test velocity_without_translation ≈ velocity_with_translation
+        end
+
+        @testset "GivenRotationOfOrigin_WhenComputeVelocity_ThenSameSpeed" begin
+            # ---- GIVEN ----
+            circulation = 1 / 7
+            source = [0.5, 0.7]
+            target = [1.1, 1.7]
+
+            rotation_angle = 30.0
+            rotation_matrix = [
+                cosd(-rotation_angle) -sind(-rotation_angle)
+                sind(-rotation_angle) cosd(-rotation_angle)
+            ]
+            rotated_source = rotation_matrix * source
+            rotated_target = rotation_matrix * target
+
+            # ---- WHEN ----
+            velocity_without_rotation = compute_velocity(circulation, source, target)
+            velocity_with_rotation = compute_velocity(
+                circulation, rotated_source, rotated_target
+            )
+
+            # ---- THEN ----
+            @test norm(velocity_without_rotation) ≈ norm(velocity_with_rotation)
+        end
+
+        @testset "GivenSwitchSourceAndTarget_WhenComputeVelocity_ThenOppositeVelocity" begin
+            # ---- GIVEN ----
+            circulation = 1 / 11
+            source = [0.7, 1.1]
+            target = [1.3, 2.3]
+
+            # ---- WHEN ----
+            velocity_without_switch = compute_velocity(circulation, source, target)
+            velocity_with_switch = compute_velocity(circulation, target, source)
+
+            # ---- THEN ----
+            @test velocity_without_switch ≈ -velocity_with_switch
         end
     end
 
-    @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeEqualsPromoteType" begin
-        # ---- GIVEN ----
-        circulation_types = (Float16, Float32, Float64)
-        source_types = (Vector{x} for x in circulation_types)
-        target_types = (Vector{x} for x in circulation_types)
+    @testset "Singularity" begin
+        @testset "GivenSourceEqualsTarget_WhenComputeVelocity_ThenVelocityEqualsNaN" begin
+            # ---- GIVEN ----
+            circulation = 1 / 13
+            source = [0.3, 0.7]
+            target = source
 
-        # ---- WHEN ---- / ---- THEN ----
-        for ctype in circulation_types, stype in source_types, ttype in target_types
-            @test Core.Compiler.return_type(compute_velocity, Tuple{ctype,stype,ttype}) ==
-                Vector{promote_type(ctype, eltype(stype), eltype(ttype))}
+            # ---- WHEN ----
+            velocity = compute_velocity(circulation, source, target)
+
+            # ---- THEN ----
+            @test all(x -> isnan(x), velocity)
+        end
+    end
+
+    @testset "Orthogonality" begin
+        @testset "GivenCirculationSourceAndTarget_WhenComputeVelocity_ThenVelocityPerpendicularToDistance" begin
+            # ---- GIVEN ----
+            circulation = 1 / 17
+            source = [0.7, 1.1]
+            target = [1.3, 2.3]
+
+            # ---- WHEN ----
+            velocity = compute_velocity(circulation, source, target)
+
+            # ---- THEN ----
+            @test dot(target, velocity) ≈ dot(source, velocity)
+        end
+    end
+
+    @testset "Proportionality" begin
+        @testset "GivenDoubleCirculation_WhenComputeVelocity_ThenDoubleVelocity" begin
+            # ---- GIVEN ----
+            circulation = 3 / 7
+            source = [1.3, 1.7]
+            target = [2.3, 2.9]
+
+            # ---- WHEN ----
+            velocity_single_circulation = compute_velocity(circulation, source, target)
+            velocity_double_circulation = compute_velocity(2 * circulation, source, target)
+
+            # ---- THEN ----
+            @test velocity_double_circulation ≈ 2 * velocity_single_circulation
+        end
+
+        @testset "GivenDoubleDistance_WhenComputeVelocity_ThenHalfVelocity" begin
+            # ---- GIVEN ----
+            circulation = 3 / 11
+            source = [0.3, 0.7]
+            target = [1.3, 2.3]
+
+            # ---- WHEN ----
+            velocity_single_distance = compute_velocity(circulation, source, target)
+            velocity_double_distance = compute_velocity(circulation, 2 * source, 2 * target)
+
+            # ---- THEN ----
+            @test velocity_double_distance ≈ 0.5 * velocity_single_distance
+        end
+
+        @testset "GivenUnitCirculationAndUnitDistance_WhenComputeVelocity_ThenSpeedEqualsReciprocalOfTwoPi" begin
+            # ---- GIVEN ----
+            circulation = 1.0
+            source = [3 / 7, 11 / 13]
+            target = source + [0.8, 0.6]
+
+            # ---- WHEN ----
+            velocity = compute_velocity(circulation, source, target)
+
+            # ---- THEN ----
+            @test norm(velocity) ≈ 1 / (2 * pi)
+        end
+    end
+
+    @testset "Return type" begin
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeIsConcrete" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test isconcretetype(
+                    Core.Compiler.return_type(compute_velocity, Tuple{ctype,stype,ttype})
+                )
+            end
+        end
+
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeEqualsPromoteType" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test Core.Compiler.return_type(
+                    compute_velocity, Tuple{ctype,stype,ttype}
+                ) == Vector{promote_type(ctype, eltype(stype), eltype(ttype))}
+            end
+        end
+    end
+end
+
+@testset "Velocity gradient" begin
+    @testset "Symmetries" begin
+        @testset "GivenCirculationSourceAndTarget_WhenComputeVelocityGradient_ThenSymmetricVelocityGradient" begin
+            # ---- GIVEN ----
+            circulation = 5 / 7
+            source = [11 / 7, 13 / 7]
+            target = [17 / 7, 23 / 7]
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test velocity_gradient == velocity_gradient'
+        end
+
+        @testset "GivenHorizontalDistanceEqualsVerticalDistance_WhenComputeVelocityGradient_ThenOffDiagonalVelocityGradientsEqualZero" begin
+            # ---- GIVEN ----
+            circulation = 13 / 7
+            source = [3 / 7, 5 / 7]
+            target = source + [3 / 11, 3 / 11]
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test velocity_gradient[2, 1] ≈ velocity_gradient[1, 2]
+            @test isapprox(velocity_gradient[2, 1], 0, atol=1e-12)
+        end
+
+        @testset "GivenAbsHorizontalDistanceLargerThanAbsVerticalDistance_WhenComputeVelocityGradient_ThenOffDiagonalVelocityGradientsAreNegative" begin
+            # ---- GIVEN ----
+            circulation = 13 / 7
+            source = [3 / 7, 5 / 7]
+            target = source + [7 / 11, 3 / 11]
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test velocity_gradient[2, 1] < 0
+            @test velocity_gradient[1, 2] < 0
+        end
+
+        @testset "GivenFlipHorizontalDistance_WhenComputeVelocityGradient_ThenFlipVelocityGradientDiagonal" begin
+            # ---- GIVEN ----
+            circulation = 13 / 7
+            source = [3 / 7, 5 / 7]
+            target = [17 / 7, 23 / 7]
+
+            source_flipped = [target[1], source[2]]
+            target_flipped = [source[1], target[2]]
+
+            # ---- WHEN ----
+            velocity_gradient_without_flip = compute_velocity_gradient(
+                circulation, source, target
+            )
+            velocity_gradient_with_flip = compute_velocity_gradient(
+                circulation, source_flipped, target_flipped
+            )
+
+            # ---- THEN ----
+            @test diag(velocity_gradient_without_flip) ≈ -diag(velocity_gradient_with_flip)
+        end
+
+        @testset "GivenPostiveHorizontalAndPostiveVerticalDistances_WhenComputeVelocityGradient_ThenFirstDiagonalPositveAndSecondDiagonalNegative" begin
+            # ---- GIVEN ----
+            circulation = 13 / 7
+            source = [3 / 11, 5 / 11]
+            target = [3 / 7, 5 / 7]
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test velocity_gradient[1, 1] > 0
+            @test velocity_gradient[2, 2] < 0
+        end
+    end
+
+    @testset "Proportionality" begin
+        @testset "GivenDoubleCiculation_WhenComputeVelocityGradient_ThenDoubleVelocityGradient" begin
+            # ---- GIVEN ----
+            circulation = 2 / 3
+            source = [1 / 7, 2 / 7]
+            target = [3 / 7, 4 / 7]
+
+            # ---- WHEN ----
+            velocity_gradient_single_circulation = compute_velocity_gradient(
+                circulation, source, target
+            )
+            velocity_gradient_double_circulation = compute_velocity_gradient(
+                2 * circulation, source, target
+            )
+
+            # ---- THEN ----
+            @test velocity_gradient_double_circulation ≈
+                2 * velocity_gradient_single_circulation
+        end
+
+        @testset "GivenDoubleDistance_WhenComputeVelocityGradient_ThenDoubleVelocityGradient" begin
+            # ---- GIVEN ----
+            circulation = 2 / 3
+            source = [1 / 7, 2 / 7]
+            target = [3 / 7, 5 / 7]
+
+            # ---- WHEN ----
+            velocity_gradient_single_distance = compute_velocity_gradient(
+                circulation, source, target
+            )
+            velocity_gradient_double_distance = compute_velocity_gradient(
+                circulation, 2 * source, 2 * target
+            )
+
+            # ---- THEN ----
+            @test velocity_gradient_double_distance ≈
+                0.25 * velocity_gradient_single_distance
+        end
+    end
+
+    @testset "Orthogonality" begin
+        @testset "GivenCirculationSourceAndTarget_WhenComputeVelocityGradient_ThenOrthogonalVelocityGradientColumns" begin
+            # ---- GIVEN ----
+            circulation = 2 / 3
+            source = [1 / 7, 2 / 7]
+            target = [3 / 7, 5 / 7]
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test dot(velocity_gradient[:, 1], velocity_gradient[:, 2]) ≈ 0
+        end
+
+        @testset "GivenUnitCirculationUnitHorizontalDistanceAndUnitVerticalDistance_WhenComputeVelocityGradient_ThenAbsDiagonalEqualReciprocalOfEightPi" begin
+            # ---- GIVEN ----
+            circulation = 1.0
+            source = [1 / 7, 2 / 7]
+            target = source + [1.0, 1.0]
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test all(x -> abs(x) ≈ 1 / (8 * pi), diag(velocity_gradient))
+        end
+    end
+
+    @testset "Singularity" begin
+        @testset "GivenSourceEqualsTarget_WhenComputeVelocityGradient_ThenVelocityGradientEqualsNaN" begin
+            # ---- GIVEN ----
+            circulation = 1 / 13
+            source = [0.3, 0.7]
+            target = source
+
+            # ---- WHEN ----
+            velocity_gradient = compute_velocity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test all(x -> isnan(x), velocity_gradient)
+        end
+    end
+
+    @testset "Return type" begin
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocityGradient_ThenReturnTypeIsConcrete" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test isconcretetype(
+                    Core.Compiler.return_type(
+                        compute_velocity_gradient, Tuple{ctype,stype,ttype}
+                    ),
+                )
+            end
+        end
+
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocityGradient_ThenReturnTypeEqualsPromoteType" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test Core.Compiler.return_type(
+                    compute_velocity_gradient, Tuple{ctype,stype,ttype}
+                ) == Matrix{promote_type(ctype, eltype(stype), eltype(ttype))}
+            end
         end
     end
 end

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -459,3 +459,65 @@ end
         end
     end
 end
+
+@testset "Vorticity gradient" begin
+    @testset "Singularity" begin
+        @testset "GivenCirculationUnequalToZeroAndSourceUnequalToTarget_WhenComputeVorticityGradient_ThenZeroVorticityGradient" begin
+            # ---- GIVEN ----
+            circulation = 1 / pi
+            source = [3 / pi, 5 / pi]
+            target = [7 / pi, 11 / pi]
+
+            # ---- WHEN ----
+            vorticity_gradient = compute_vorticity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test all(x -> isapprox(x, 0; atol=1e-12), vorticity_gradient)
+        end
+
+        @testset "GivenSourceEqualsTarget_WhenComputeVorticityGradient_ThenVorticityGradientEqualsNaN" begin
+            # ---- GIVEN ----
+            circulation = 1 / 13
+            source = [0.3, 0.7]
+            target = source
+
+            # ---- WHEN ----
+            vorticity_gradient = compute_vorticity_gradient(circulation, source, target)
+
+            # ---- THEN ----
+            @test all(x -> isnan(x), vorticity_gradient)
+        end
+    end
+
+    @testset "Return type" begin
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVorticityGradient_ThenReturnTypeIsConcrete" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test isconcretetype(
+                    Core.Compiler.return_type(
+                        compute_vorticity_gradient, Tuple{ctype,stype,ttype}
+                    ),
+                )
+            end
+        end
+
+        @testset "GivenFloatAndFloatVectorInputs_WhenComputeVorticityGradient_ThenReturnTypeEqualsPromoteType" begin
+            # ---- GIVEN ----
+            circulation_types = (Float16, Float32, Float64)
+            source_types = (Vector{x} for x in circulation_types)
+            target_types = (Vector{x} for x in circulation_types)
+
+            # ---- WHEN ---- / ---- THEN ----
+            for ctype in circulation_types, stype in source_types, ttype in target_types
+                @test Core.Compiler.return_type(
+                    compute_vorticity_gradient, Tuple{ctype,stype,ttype}
+                ) == Matrix{promote_type(ctype, eltype(stype), eltype(ttype))}
+            end
+        end
+    end
+end

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -1,0 +1,165 @@
+using LinearAlgebra
+using Test
+using VEM
+
+@testset "Symmetries" begin
+    @testset "GivenTranslationOfOrigin_WhenComputeVelocity_ThenSameVelocity" begin
+        # ---- GIVEN ----
+        circulation = 1.0
+        source = [0.0, 0.0]
+        target = [1.0, 0.0]
+
+        translation = [1.0, 1.0]
+        translated_source = source - translation
+        translated_target = target - translation
+
+        # ---- WHEN ----
+        velocity_without_translation = compute_velocity(circulation, source, target)
+        velocity_with_translation = compute_velocity(
+            circulation, translated_source, translated_target
+        )
+
+        # ---- THEN ----
+        @test velocity_without_translation == velocity_with_translation
+    end
+
+    @testset "GivenRotationOfOrigin_WhenComputeVelocity_ThenSameSpeed" begin
+        # ---- GIVEN ----
+        circulation = 1.0
+        source = [1.0, 0.5]
+        target = [0.75, 0.75]
+
+        rotation_angle = 30.0
+        rotation_matrix = [
+            cosd(-rotation_angle) -sind(-rotation_angle)
+            sind(-rotation_angle) cosd(-rotation_angle)
+        ]
+        rotated_source = rotation_matrix * source
+        rotated_target = rotation_matrix * target
+
+        # ---- WHEN ----
+        velocity_without_rotation = compute_velocity(circulation, source, target)
+        velocity_with_rotation = compute_velocity(
+            circulation, rotated_source, rotated_target
+        )
+
+        # ---- THEN ----
+        @test norm(velocity_without_rotation) ≈ norm(velocity_with_rotation)
+    end
+
+    @testset "GivenSwitchSourceAndTarget_WhenComputeVelocity_ThenOppositeVelocity" begin
+        # ---- GIVEN ----
+        circulation = 1.0
+        source = [0.0, 0.0]
+        target = [1.0, 0.0]
+
+        # ---- WHEN ----
+        velocity_without_switch = compute_velocity(circulation, source, target)
+        velocity_with_switch = compute_velocity(circulation, target, source)
+
+        # ---- THEN ----
+        @test velocity_without_switch == -velocity_with_switch
+    end
+end
+
+@testset "Singularity" begin
+    @testset "GivenSourceEqualsTarget_WhenComputeVelocity_ThenVelocityEqualsNaN" begin
+        # ---- GIVEN ----
+        circulation = 1.0
+        source = [0.5, 0.5]
+        target = source
+
+        # ---- WHEN ----
+        velocity = compute_velocity(circulation, source, target)
+
+        # ---- THEN ----
+        @test all(x -> isnan(x), velocity)
+    end
+end
+
+@testset "Orthogonality" begin
+    @testset "GivenCirculationSourceAndTarget_WhenComputeVelocity_ThenVelocityPerpendicularToDistance" begin
+        # ---- GIVEN ----
+        circulation = 1.0
+        source = [0.25, 0.75]
+        target = [0.75, 0.25]
+
+        # ---- WHEN ----
+        velocity = compute_velocity(circulation, source, target)
+
+        # ---- THEN ----
+        @test dot(target - source, velocity) ≈ 0.0
+    end
+end
+
+@testset "Proportionality" begin
+    @testset "GivenDoubleCirculation_WhenComputeVelocity_ThenDoubleVelocity" begin
+        # ---- GIVEN ----
+        circulation = 3.0
+        source = [0.25, 0.75]
+        target = [0.75, 0.25]
+
+        # ---- WHEN ----
+        velocity_single_circulation = compute_velocity(circulation, source, target)
+        velocity_double_circulation = compute_velocity(2 * circulation, source, target)
+
+        # ---- THEN ----
+        @test velocity_double_circulation == 2 * velocity_single_circulation
+    end
+
+    @testset "GivenDoubleDistance_WhenComputeVelocity_ThenHalfVelocity" begin
+        # ---- GIVEN ----
+        circulation = 3.0
+        source = [0.25, 0.75]
+        target = [0.75, 0.25]
+
+        # ---- WHEN ----
+        velocity_single_distance = compute_velocity(circulation, source, target)
+        velocity_double_distance = compute_velocity(circulation, 2 * source, 2 * target)
+
+        # ---- THEN ----
+        @test velocity_double_distance == 0.5 * velocity_single_distance
+    end
+
+    @testset "GivenUnitCirculationAndUnitDistance_WhenComputeVelocity_ThenSpeedEqualsReciprocalOfTwoPi" begin
+        # ---- GIVEN ----
+        circulation = 1.0
+        source = [0.0, 1.0]
+        target = [0.0, 2.0]
+
+        # ---- WHEN ----
+        velocity = compute_velocity(circulation, source, target)
+
+        # ---- THEN ----
+        @test norm(velocity) == 1 / (2 * pi)
+    end
+end
+
+@testset "Return type" begin
+    @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeIsConcrete" begin
+        # ---- GIVEN ----
+        circulation_types = (Float16, Float32, Float64)
+        source_types = (Vector{x} for x in circulation_types)
+        target_types = (Vector{x} for x in circulation_types)
+
+        # ---- WHEN ---- / ---- THEN ----
+        for ctype in circulation_types, stype in source_types, ttype in target_types
+            @test isconcretetype(
+                Core.Compiler.return_type(compute_velocity, Tuple{ctype,stype,ttype})
+            )
+        end
+    end
+
+    @testset "GivenFloatAndFloatVectorInputs_WhenComputeVelocity_ThenReturnTypeEqualsPromoteType" begin
+        # ---- GIVEN ----
+        circulation_types = (Float16, Float32, Float64)
+        source_types = (Vector{x} for x in circulation_types)
+        target_types = (Vector{x} for x in circulation_types)
+
+        # ---- WHEN ---- / ---- THEN ----
+        for ctype in circulation_types, stype in source_types, ttype in target_types
+            @test Core.Compiler.return_type(compute_velocity, Tuple{ctype,stype,ttype}) ==
+                Vector{promote_type(ctype, eltype(stype), eltype(ttype))}
+        end
+    end
+end

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -5,9 +5,9 @@ using VEM
 @testset "Symmetries" begin
     @testset "GivenTranslationOfOrigin_WhenComputeVelocity_ThenSameVelocity" begin
         # ---- GIVEN ----
-        circulation = 1.0
-        source = [0.0, 0.0]
-        target = [1.0, 0.0]
+        circulation = 1 / 3
+        source = [0.3, 0.5]
+        target = [0.7, 1.1]
 
         translation = [1.0, 1.0]
         translated_source = source - translation
@@ -20,14 +20,14 @@ using VEM
         )
 
         # ---- THEN ----
-        @test velocity_without_translation == velocity_with_translation
+        @test velocity_without_translation ≈ velocity_with_translation
     end
 
     @testset "GivenRotationOfOrigin_WhenComputeVelocity_ThenSameSpeed" begin
         # ---- GIVEN ----
-        circulation = 1.0
-        source = [1.0, 0.5]
-        target = [0.75, 0.75]
+        circulation = 1 / 7
+        source = [0.5, 0.7]
+        target = [1.1, 1.7]
 
         rotation_angle = 30.0
         rotation_matrix = [
@@ -49,24 +49,24 @@ using VEM
 
     @testset "GivenSwitchSourceAndTarget_WhenComputeVelocity_ThenOppositeVelocity" begin
         # ---- GIVEN ----
-        circulation = 1.0
-        source = [0.0, 0.0]
-        target = [1.0, 0.0]
+        circulation = 1 / 11
+        source = [0.7, 1.1]
+        target = [1.3, 2.3]
 
         # ---- WHEN ----
         velocity_without_switch = compute_velocity(circulation, source, target)
         velocity_with_switch = compute_velocity(circulation, target, source)
 
         # ---- THEN ----
-        @test velocity_without_switch == -velocity_with_switch
+        @test velocity_without_switch ≈ -velocity_with_switch
     end
 end
 
 @testset "Singularity" begin
     @testset "GivenSourceEqualsTarget_WhenComputeVelocity_ThenVelocityEqualsNaN" begin
         # ---- GIVEN ----
-        circulation = 1.0
-        source = [0.5, 0.5]
+        circulation = 1 / 13
+        source = [0.3, 0.7]
         target = source
 
         # ---- WHEN ----
@@ -80,58 +80,58 @@ end
 @testset "Orthogonality" begin
     @testset "GivenCirculationSourceAndTarget_WhenComputeVelocity_ThenVelocityPerpendicularToDistance" begin
         # ---- GIVEN ----
-        circulation = 1.0
-        source = [0.25, 0.75]
-        target = [0.75, 0.25]
+        circulation = 1 / 17
+        source = [0.7, 1.1]
+        target = [1.3, 2.3]
 
         # ---- WHEN ----
         velocity = compute_velocity(circulation, source, target)
 
         # ---- THEN ----
-        @test dot(target - source, velocity) ≈ 0.0
+        @test dot(target, velocity) ≈ dot(source, velocity)
     end
 end
 
 @testset "Proportionality" begin
     @testset "GivenDoubleCirculation_WhenComputeVelocity_ThenDoubleVelocity" begin
         # ---- GIVEN ----
-        circulation = 3.0
-        source = [0.25, 0.75]
-        target = [0.75, 0.25]
+        circulation = 3 / 7
+        source = [1.3, 1.7]
+        target = [2.3, 2.9]
 
         # ---- WHEN ----
         velocity_single_circulation = compute_velocity(circulation, source, target)
         velocity_double_circulation = compute_velocity(2 * circulation, source, target)
 
         # ---- THEN ----
-        @test velocity_double_circulation == 2 * velocity_single_circulation
+        @test velocity_double_circulation ≈ 2 * velocity_single_circulation
     end
 
     @testset "GivenDoubleDistance_WhenComputeVelocity_ThenHalfVelocity" begin
         # ---- GIVEN ----
-        circulation = 3.0
-        source = [0.25, 0.75]
-        target = [0.75, 0.25]
+        circulation = 3 / 11
+        source = [0.3, 0.7]
+        target = [1.3, 2.3]
 
         # ---- WHEN ----
         velocity_single_distance = compute_velocity(circulation, source, target)
         velocity_double_distance = compute_velocity(circulation, 2 * source, 2 * target)
 
         # ---- THEN ----
-        @test velocity_double_distance == 0.5 * velocity_single_distance
+        @test velocity_double_distance ≈ 0.5 * velocity_single_distance
     end
 
     @testset "GivenUnitCirculationAndUnitDistance_WhenComputeVelocity_ThenSpeedEqualsReciprocalOfTwoPi" begin
         # ---- GIVEN ----
         circulation = 1.0
-        source = [0.0, 1.0]
-        target = [0.0, 2.0]
+        source = [3 / 7, 11 / 13]
+        target = source + [0.8, 0.6]
 
         # ---- WHEN ----
         velocity = compute_velocity(circulation, source, target)
 
         # ---- THEN ----
-        @test norm(velocity) == 1 / (2 * pi)
+        @test norm(velocity) ≈ 1 / (2 * pi)
     end
 end
 

--- a/test/singular_vortex_particle.jl
+++ b/test/singular_vortex_particle.jl
@@ -335,7 +335,7 @@ end
             velocity_gradient = compute_velocity_gradient(circulation, source, target)
 
             # ---- THEN ----
-            @test dot(velocity_gradient[:, 1], velocity_gradient[:, 2]) ≈ 0
+            @test isapprox(dot(velocity_gradient[:, 1], velocity_gradient[:, 2]), 0; atol=1e-12)
         end
 
         @testset "GivenUnitCirculationUnitHorizontalDistanceAndUnitVerticalDistance_WhenComputeVelocityGradient_ThenAbsDiagonalEqualReciprocalOfEightPi" begin


### PR DESCRIPTION
Add induction kernels:

- `compute_velocity`
- `compute_velocity_gradient`
- `compute_vorticity`
- `compute_vorticity_gradient`

for computing the velocity, velocity gradient, vorticity and vorticity gradient induced by a 2D singular irrotational vortex.