### PR TITLE
Add redistribution of vortex blobs onto a Cartesian mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Advection of a collection of vortex blobs: `advection!`. ([#5])
 
 - Concrete type for a Cartesian mesh: `CartesianMesh`. ([#9])
+- Abstract type representing a vortex-blob redistribution kernel: `AbstractRedistributionKernel`. ([#9])
+- Concrete type for the M4' redistribution kernel: `M4Prime`. ([#9])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Concrete type for a Cartesian mesh: `CartesianMesh`. ([#9])
 - Abstract type representing a vortex-blob redistribution kernel: `AbstractRedistributionKernel`. ([#9])
 - Concrete type for the M4' redistribution kernel: `M4Prime`. ([#9])
+- Function to redistribute blobs onto nodes of a Cartesian mesh: `redistribute`. ([#9])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Abstract interface for an induced field: `AbstractInducedField`. ([#7])
 - Concrete types for a velocity field and a vorticity field: `VelocityField` and `VorticityField`. ([#7])
 
-- Function to compute the field value induced by a vortex blob at a target: `induce`. ([#7])
-- Multi-threaded CPU implementation for the direct summation of fields induced by a collection of vortex blobs at a collection of targets: `direct_sum` and `direct_sum!`. ([#7])
+- Computation of the field value induced by a vortex blob at a target: `induce`. ([#7])
+- Multi-threaded CPU implementation for the direct summation of field inductions by a collection of vortex blobs at a collection of targets: `direct_sum` and `direct_sum!`. ([#7])
 
 - Advection of a collection of vortex blobs: `advection!`. ([#5])
 
 - Concrete type for a Cartesian mesh: `CartesianMesh`. ([#9])
-- Abstract type representing a vortex-blob redistribution kernel: `AbstractRedistributionKernel`. ([#9])
+  
+- Abstract interface for a vortex-blob redistribution kernel: `AbstractRedistributionKernel`. ([#9])
 - Concrete type for the M4' redistribution kernel: `M4Prime`. ([#9])
-- Function to interpolate blob circulations onto Cartesian mesh nodes: `interpolate_circulation`. ([#9])
-- Function to create redistributed blobs from old blobs and a Cartesian mesh: `redistribution`. ([#9])
+
+- Interpolation of  blob circulations onto Cartesian mesh nodes: `interpolate_circulation`. ([#9])
+- Redistribution from olds blobs to new blobs at Cartesian mesh nodes: `redistribution`. ([#9])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Advection of a collection of vortex blobs: `advection!`. ([#5])
 
+- Concrete type for a Cartesian mesh: `CartesianMesh`. ([#9])
+
 ### Changed
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Abstract type representing a vortex-blob redistribution kernel: `AbstractRedistributionKernel`. ([#9])
 - Concrete type for the M4' redistribution kernel: `M4Prime`. ([#9])
 - Function to interpolate blob circulations onto Cartesian mesh nodes: `interpolate_circulation`. ([#9])
+- Function to create redistributed blobs from old blobs and a Cartesian mesh: `redistribution`. ([#9])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Concrete type for a Cartesian mesh: `CartesianMesh`. ([#9])
 - Abstract type representing a vortex-blob redistribution kernel: `AbstractRedistributionKernel`. ([#9])
 - Concrete type for the M4' redistribution kernel: `M4Prime`. ([#9])
-- Function to redistribute blobs onto nodes of a Cartesian mesh: `redistribute`. ([#9])
+- Function to interpolate blob circulations onto Cartesian mesh nodes: `interpolate_circulation`. ([#9])
 
 ### Changed
 

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -40,6 +40,15 @@ export direct_sum!
 include("blob/advection.jl")
 export advection!
 
+include("blob/cartesian_mesh.jl")
+export CartesianMesh
+export mesh_dimension
+export mesh_scalar
+export cells_per_axis
+export nodes_per_axis
+export node_spacing
+export mesh_nodes
+
 include("precompile.jl")
 
 end

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -47,6 +47,7 @@ export mesh_scalar
 export cells_per_axis
 export nodes_per_axis
 export node_spacing
+export mesh_bounds
 export mesh_nodes
 
 include("blob/redistribution_kernel.jl")
@@ -54,6 +55,9 @@ export AbstractRedistributionKernel
 export M4Prime
 export redistribution_weight
 export support_radius
+
+include("blob/redistribution.jl")
+export redistribute
 
 include("precompile.jl")
 

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -28,6 +28,7 @@ include("blob/field_interface.jl")
 export AbstractInducedField
 export VelocityField
 export VorticityField
+export field_scalar
 
 include("blob/gaussian_blob.jl")
 export GaussianVortexBlob

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -57,7 +57,7 @@ export redistribution_weight
 export support_radius
 
 include("blob/redistribution.jl")
-export redistribute
+export interpolate_circulation
 
 include("precompile.jl")
 

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -57,6 +57,7 @@ export redistribution_weight
 export support_radius
 
 include("blob/redistribution.jl")
+export redistribution
 export interpolate_circulation
 
 include("precompile.jl")

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -49,6 +49,12 @@ export nodes_per_axis
 export node_spacing
 export mesh_nodes
 
+include("blob/redistribution_kernel.jl")
+export AbstractRedistributionKernel
+export M4Prime
+export redistribution_weight
+export support_radius
+
 include("precompile.jl")
 
 end

--- a/src/blob/blob_interface.jl
+++ b/src/blob/blob_interface.jl
@@ -6,6 +6,19 @@ Abstract type representing a vortex blob in `Dimension`-dimensional space, param
 abstract type AbstractVortexBlob{Dimension,Scalar<:AbstractFloat} end
 
 """
+    Base.zero(blob::AbstractVortexBlob)
+
+Return a vortex blob with all data set to 0.
+
+# Arguments
+- `blob`: An instance of a vortex blob.
+
+# Returns
+A vortex blob instance with zero circulation, center, and radius.
+"""
+Base.zero(blob::AbstractVortexBlob) = zero(typeof(blob))
+
+"""
     blob_dimension(blob::AbstractVortexBlob)
 
 # Arguments

--- a/src/blob/cartesian_mesh.jl
+++ b/src/blob/cartesian_mesh.jl
@@ -1,7 +1,7 @@
 """
     CartesianMesh{Dimension,Scalar<:AbstractFloat}(cells_per_axis::NTuple{Dimension,Int}, spacing::Scalar)
 
-    A Cartesian mesh for vortex blob methods.
+A Cartesian mesh for vortex blob methods.
 
 # Argumentss
 - `cells_per_axis: The number of cells along each axis.

--- a/src/blob/cartesian_mesh.jl
+++ b/src/blob/cartesian_mesh.jl
@@ -1,0 +1,104 @@
+"""
+    CartesianMesh{Dimension,Scalar<:AbstractFloat}(cells_per_axis::NTuple{Dimension,Int}, spacing::Scalar)
+
+    A Cartesian mesh for vortex blob methods.
+
+# Argumentss
+- `cells_per_axis: The number of cells along each axis.
+- `spacing`: The spacing between nodes in the mesh.
+"""
+struct CartesianMesh{Dimension,Scalar<:AbstractFloat}
+    cells_per_axis::NTuple{Dimension,Int}
+    spacing::Scalar
+end
+
+"""
+    mesh_dimension(::CartesianMesh)
+
+Get the dimension of the `CartesianMesh`.
+
+# Arguments
+- `::CartesianMesh`: The Cartesian mesh.
+
+# Returns
+The dimension of the Cartesian mesh.
+"""
+mesh_dimension(::CartesianMesh{Dimension}) where {Dimension} = Dimension
+
+"""
+    mesh_scalar(::CartesianMesh)
+
+Get the scalar type of the `CartesianMesh`.
+
+# Arguments
+- `::CartesianMesh`: The Cartesian mesh.
+
+# Returns
+The scalar type of the Cartesian mesh.
+"""
+mesh_scalar(::CartesianMesh{Dimension,Scalar}) where {Dimension,Scalar} = Scalar
+
+"""
+    cells_per_axis(mesh::CartesianMesh)
+
+Get the number of cells per axis in the `mesh`.
+
+# Arguments
+- `mesh`: The Cartesian mesh.
+
+# Returns
+The number of cells per axis in the Cartesian mesh.
+"""
+cells_per_axis(mesh::CartesianMesh) = mesh.cells_per_axis
+
+"""
+    nodes_per_axis(::CartesianMesh)
+
+Get the number of nodes per axis in the `mesh`.
+
+# Arguments
+- `mesh`: The Cartesian mesh.
+
+# Returns
+The number of nodes per axis in the Cartesian mesh.
+"""
+nodes_per_axis(mesh::CartesianMesh) = mesh.cells_per_axis .+ 1
+
+"""
+    node_spacing(::CartesianMesh)
+
+Get the spacing between nodes in the `mesh`.
+
+# Arguments
+- `mesh`: The Cartesian mesh.
+
+# Returns
+The spacing between nodes in the Cartesian mesh.
+"""
+node_spacing(mesh::CartesianMesh) = mesh.spacing
+
+"""
+    mesh_nodes(mesh)
+
+Get the nodes of the `mesh`.
+
+# Arguments
+- `mesh`: The Cartesian mesh.
+
+# Returns
+The nodes of the Cartesian mesh as a matrix of static vectors.
+"""
+function mesh_nodes(mesh::CartesianMesh)
+    dimension = mesh_dimension(mesh)
+    scalar = mesh_scalar(mesh)
+    size = nodes_per_axis(mesh)
+    spacing = node_spacing(mesh)
+
+    nodes = zeros(SA.SVector{dimension,scalar}, size)
+
+    Threads.@threads for index in CartesianIndices(size)
+        @inbounds nodes[index] = (index.I .- 1) .* spacing
+    end
+
+    return nodes
+end

--- a/src/blob/cartesian_mesh.jl
+++ b/src/blob/cartesian_mesh.jl
@@ -78,6 +78,26 @@ The spacing between nodes in the Cartesian mesh.
 node_spacing(mesh::CartesianMesh) = mesh.spacing
 
 """
+    mesh_bounds(mesh::CartesianMesh)
+
+Get the bounds of the `mesh`.
+
+# Arguments
+- `mesh`: The Cartesian mesh.
+
+# Returns
+The bounds of the Cartesian mesh as a tuple of tuples, where each inner tuple contains the minimum and maximum bounds along each axis.
+"""
+function mesh_bounds(mesh::CartesianMesh)
+    scalar = mesh_scalar(mesh)
+    spacing = node_spacing(mesh)
+
+    bounds = Tuple((zero(scalar), n * spacing) for n in cells_per_axis(mesh))
+
+    return bounds
+end
+
+"""
     mesh_nodes(mesh)
 
 Get the nodes of the `mesh`.

--- a/src/blob/field_interface.jl
+++ b/src/blob/field_interface.jl
@@ -12,6 +12,18 @@ A singleton type representing a velocity field.
 """
 struct VelocityField <: AbstractInducedField end
 
+"""
+    field_scalar(::VelocityField, blob::AbstractVortexBlob)
+
+Determine the scalar type of the velocity field induced by a vortex blob.
+
+# Arguments
+- `::VelocityField`: The type of field that is induced.
+- `blob`: The vortex blob for which the field is being induced.
+
+# Returns
+The scalar type of the velocity field induced by the vortex blob.
+"""
 function field_scalar(
     ::VelocityField, blob::AbstractVortexBlob{Dimension,Scalar}
 ) where {Dimension,Scalar}

--- a/src/blob/gaussian_blob.jl
+++ b/src/blob/gaussian_blob.jl
@@ -49,6 +49,24 @@ function GaussianVortexBlob(circulation, center, radius)
 end
 
 """
+    zero(::Type{GaussianVortexBlob{Dimension,Scalar}}) where {Dimension, Scalar}
+
+Return a `GaussianVortexBlob` with all data set to 0.
+
+# Arguments
+- `GaussianVortexBlob{Dimension,Scalar}`: The type of a vortex blob..
+
+# Returns
+A `GaussianVortexBlob` instance with zero circulation, center, and radius.
+"""
+function Base.zero(::Type{GaussianVortexBlob{2,Scalar}}) where {Scalar}
+    return GaussianVortexBlob(zero(Scalar), zero(SA.SVector{2,Scalar}), zero(Scalar))
+end
+function Base.zero(::Type{GaussianVortexBlob{3,Scalar}}) where {Scalar}
+    return GaussianVortexBlob(zero(SA.SVector{3,Scalar}), zero(SA.SVector{3,Scalar}), zero(Scalar))
+end
+
+"""
     induce(::VelocityField, blob::GaussianVortexBlob{2}, target)
 
 Compute the velocity induced at `target` due to a 2D Gaussian vortex blob.

--- a/src/blob/redistribution.jl
+++ b/src/blob/redistribution.jl
@@ -1,4 +1,4 @@
-function redistribute(blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
+function interpolate_circulation(blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
     if !inside_mesh(blobs, mesh)
         throw(ArgumentError("All blobs must reside within the redistribution mesh."))
     end

--- a/src/blob/redistribution.jl
+++ b/src/blob/redistribution.jl
@@ -1,3 +1,16 @@
+"""
+    redistribution(old_blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
+
+Redistribute the `old_blobs` onto the `mesh` using the redistribution `kernel`.
+
+# Arguments
+- `old_blobs`: The vortex blobs to be redistributed.
+- `mesh`: The Cartesian mesh onto which the blobs will be redistributed at the nodes.
+- `kernel`: The redistribution kernel that determines the weights for redistribution.
+
+# Returns
+The redistributed vortex blobs at the nodes of the Cartesian `mesh`.
+"""
 function redistribution(old_blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
     Blob = eltype(old_blobs)
     new_blobs = zeros(Blob, nodes_per_axis(mesh))
@@ -15,6 +28,19 @@ function redistribution(old_blobs, mesh::CartesianMesh, kernel::AbstractRedistri
     return new_blobs
 end
 
+"""
+    interpolate_circulation(blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
+
+Interpolate the circulation of the `blobs` onto the nodes of the `mesh` using the redistribution `kernel`.
+
+# Arguments
+- `blobs`: The vortex blobs whose circulation is to be interpolated.
+- `mesh`: The Cartesian mesh onto which the circulation will be interpolated at the nodes.
+- `kernel`: The redistribution kernel that determines the weights for interpolation.
+
+# Returns
+The interpolated circulation at the nodes of the Cartesian `mesh`.
+"""
 function interpolate_circulation(blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
     if !inside_mesh(blobs, mesh)
         throw(ArgumentError("All blobs must reside within the redistribution mesh."))

--- a/src/blob/redistribution.jl
+++ b/src/blob/redistribution.jl
@@ -1,3 +1,20 @@
+function redistribution(old_blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
+    Blob = eltype(old_blobs)
+    new_blobs = zeros(Blob, nodes_per_axis(mesh))
+
+    circulations = interpolate_circulation(old_blobs, mesh, kernel)
+    radius = blob_radius(old_blobs[1])
+    spacing = node_spacing(mesh)
+
+    Threads.@threads for index in CartesianIndices(circulations)
+        circulation = circulations[index]
+        center = Tuple((i - 1) * spacing for i in Tuple(index))
+        new_blobs[index] = Blob(circulation, center, radius)
+    end
+
+    return new_blobs
+end
+
 function interpolate_circulation(blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
     if !inside_mesh(blobs, mesh)
         throw(ArgumentError("All blobs must reside within the redistribution mesh."))

--- a/src/blob/redistribution.jl
+++ b/src/blob/redistribution.jl
@@ -1,0 +1,54 @@
+function redistribute(blobs, mesh::CartesianMesh, kernel::AbstractRedistributionKernel)
+    if !inside_mesh(blobs, mesh)
+        throw(ArgumentError("All blobs must reside within the redistribution mesh."))
+    end
+
+    mesh_dimensions = mesh_dimension(mesh)
+    mesh_spacing = node_spacing(mesh)
+    mesh_size = nodes_per_axis(mesh)
+
+    core_radius = blob_radius(blobs[1])
+    kernel_radius = support_radius(kernel)
+    influence_radius = round(Int, kernel_radius * core_radius / mesh_spacing)
+
+    redistributed_circulation = zeros(typeof(blob_circulation(blobs[1])), mesh_size)
+
+    for blob in blobs
+        circulation = blob_circulation(blob)
+        center = blob_center(blob)
+
+        reference_index = Tuple(floor(Int, x / mesh_spacing + 1) for x in center)
+        min_index = Tuple(max(1, index - influence_radius + 1) for index in reference_index)
+        max_index = Tuple(
+            min(n, index + influence_radius) for (n, index) in zip(mesh_size, reference_index)
+        )
+
+        for index in CartesianIndex(min_index):CartesianIndex(max_index)
+            weight = one(core_radius)
+
+            for dimension in 1:mesh_dimensions
+                source = center[dimension]
+                target = (index[dimension] - 1) * mesh_spacing
+                distance = (target - source) / core_radius
+                weight *= redistribution_weight(kernel, distance)
+            end
+
+            redistributed_circulation[index] += circulation * weight
+        end
+    end
+
+    return redistributed_circulation
+end
+
+function inside_mesh(blobs, mesh)
+    blobs_extent = bounding_box(blob_center(blob) for blob in blobs)
+    mesh_extent = mesh_bounds(mesh)
+
+    for (x, y) in zip(blobs_extent, mesh_extent)
+        if x[1] < y[1] || x[2] > y[2]
+            return false
+        end
+    end
+
+    return true
+end

--- a/src/blob/redistribution_kernel.jl
+++ b/src/blob/redistribution_kernel.jl
@@ -1,0 +1,49 @@
+"""
+    AbstractRedistributionKernel
+
+An abstract type representing a vortex blob redistribution kernel, which defines how weights are assigned based on distance normalized by the vortex blob core radius.
+"""
+abstract type AbstractRedistributionKernel end
+
+"""
+    M4Prime
+
+M4' is a vortex blob redistribution kernel. It is defined by a piecewise function that assigns
+weights based on the distance from the center of the vortex blob, normalized by the blob's core
+radius. The M4' kernel has a support radius of 2, meaning that it assigns non-zero weights to points
+at a distance greater than 2 core radii.
+"""
+struct M4Prime <: AbstractRedistributionKernel end
+
+"""
+    redistribution_weight(::M4Prime, distance)
+
+Compute the redistribution weight for a given distance using the M4' kernel.
+
+# Arguments
+- `::M4Prime`: An instance of the M4' redistribution kernel.
+- `distance`: The distance from the center of the vortex blob, normalized by the blob's core radius.
+
+# Returns
+The redistribution weight corresponding to the given distance.
+"""
+function redistribution_weight(::M4Prime, distance)
+    if distance <= 1
+        return distance * (-distance * 5 / 2 + distance^2 * 3 / 2) + 1
+    elseif distance <= 2
+        return (1 - distance) * (2 - distance)^2 / 2
+    else
+        return zero(distance)
+    end
+end
+
+"""
+    support_radius(::M4Prime)
+
+# Arguments
+- `::M4Prime`: An instance of the M4' redistribution kernel.
+
+# Returns
+The support radius of the M4' redistribution kernel.
+"""
+support_radius(::M4Prime) = 2

--- a/src/blob/redistribution_kernel.jl
+++ b/src/blob/redistribution_kernel.jl
@@ -28,6 +28,8 @@ Compute the redistribution weight for a given distance using the M4' kernel.
 The redistribution weight corresponding to the given distance.
 """
 function redistribution_weight(::M4Prime, distance)
+    distance = abs(distance)
+
     if distance <= 1
         return distance * (-distance * 5 / 2 + distance^2 * 3 / 2) + 1
     elseif distance <= 2

--- a/src/blob/utilities.jl
+++ b/src/blob/utilities.jl
@@ -35,3 +35,10 @@ function induced_vorticity_output_helper(circulation, mollifier, radius_squared)
     vorticity = circulation * (mollifier / (radius_squared * pi * 2))
     return vorticity
 end
+
+function bounding_box(points)
+    minimum = reduce((x, y) -> min.(x, y), points)
+    maximum = reduce((x, y) -> max.(x, y), points)
+    extent = ((x, y) for (x, y) in zip(minimum, maximum))
+    return extent
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,13 +3,13 @@ PCT.@setup_workload begin
         for Dimension in (2,)
             for Scalar in (Float32, Float64)
                 if Dimension == 2
-                    circulation = Scalar(0)
+                    circulation = Scalar(0.1)
                 elseif Dimension == 3
-                    circulation = SA.SVector{3,Scalar}(0, 0, 0)
+                    circulation = SA.SVector{3,Scalar}(0.1, 0.2, 0.3)
                 end
 
                 center = zero(SA.SVector{Dimension,Scalar})
-                radius = Scalar(0)
+                radius = Scalar(0.1)
                 target = zero(SA.SVector{Dimension,Scalar})
 
                 blobs = [
@@ -34,6 +34,10 @@ PCT.@setup_workload begin
                 advection!(blobs, 0.0, 0.1; time_scheme=ODE.Euler())
                 advection!(blobs, 0.0, 0.1; time_scheme=ODE.Midpoint())
                 advection!(blobs, 0.0, 0.1; time_scheme=ODE.RK4())
+
+                mesh = CartesianMesh((10, 10), 0.1)
+                kernel = M4Prime()
+                redistribution(blobs, mesh, kernel)
             end
         end
     end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -36,8 +36,8 @@ PCT.@setup_workload begin
                 advection!(blobs, 0.0, 0.1; time_scheme=ODE.RK4())
 
                 mesh = CartesianMesh((10, 10), 0.1)
-                kernel = M4Prime()
-                redistribution(blobs, mesh, kernel)
+
+                redistribution(blobs, mesh, M4Prime())
             end
         end
     end

--- a/test/blob/advection.jl
+++ b/test/blob/advection.jl
@@ -166,7 +166,7 @@ end
     @test isapprox(blobs[2].center, [x, y0 - r]; rtol=1e-6)
 end
 
-@testitem "Advect blobs with Runge Kutta 4 time scheme" setup = [TestAdvection] begin
+@testitem "Advect blobs with Runge-Kutta 4th order time scheme" setup = [TestAdvection] begin
     # GIVEN
 
     x0 = 0.4771646897488281

--- a/test/blob/blob_interface.jl
+++ b/test/blob/blob_interface.jl
@@ -1,0 +1,159 @@
+@testmodule TestBlobInterface2D begin
+    using VEM
+
+    # GIVEN
+
+    mutable struct Blob{D,T} <: VEM.AbstractVortexBlob{D,T}
+        circulation::T
+        center::VEM.SA.SVector{D,T}
+        radius::T
+    end
+
+    function Base.zero(::Type{Blob{D,T}}) where {D,T}
+        return Blob(zero(T), zero(VEM.SA.SVector{D,T}), zero(T))
+    end
+
+    expected_circulation = 1.0
+    expected_center = VEM.SA.SVector(0.5, 0.5)
+    expected_radius = 0.1
+
+    blob = Blob(expected_circulation, expected_center, expected_radius)
+end
+
+@testitem "Get vortex blob type parameters" setup = [TestBlobInterface2D] begin
+    # WHEN
+
+    Dimension = blob_dimension(TestBlobInterface2D.blob)
+    Scalar = blob_scalar(TestBlobInterface2D.blob)
+
+    # THEN
+
+    @test Dimension == 2
+    @test Scalar == Float64
+end
+
+@testitem "Create vortex blob with zero data" setup = [TestBlobInterface2D] begin
+    # WHEN
+
+    zero_blob = zero(TestBlobInterface2D.blob)
+
+    # THEN
+
+    @test blob_circulation(zero_blob) == 0.0
+    @test blob_center(zero_blob) == [0.0, 0.0]
+    @test blob_radius(zero_blob) == 0.0
+end
+
+@testitem "Get vortex blob data" setup = [TestBlobInterface2D] begin
+    # WHEN
+
+    circulation = blob_circulation(TestBlobInterface2D.blob)
+    center = blob_center(TestBlobInterface2D.blob)
+    radius = blob_radius(TestBlobInterface2D.blob)
+
+    # THEN
+
+    @test circulation == TestBlobInterface2D.expected_circulation
+    @test center == TestBlobInterface2D.expected_center
+    @test radius == TestBlobInterface2D.expected_radius
+end
+
+@testitem "Update vortex blob data" setup = [TestBlobInterface2D] begin
+    # GIVEN
+
+    new_expected_circulation = 2.0
+    new_expected_center = typeof(TestBlobInterface2D.expected_center)(0.6, 0.6)
+    new_expected_radius = 0.2
+
+    # WHEN
+
+    blob_circulation!(TestBlobInterface2D.blob, new_expected_circulation)
+    blob_center!(TestBlobInterface2D.blob, new_expected_center)
+    blob_radius!(TestBlobInterface2D.blob, new_expected_radius)
+
+    # THEN
+
+    @test blob_circulation(TestBlobInterface2D.blob) == new_expected_circulation
+    @test blob_center(TestBlobInterface2D.blob) == new_expected_center
+    @test blob_radius(TestBlobInterface2D.blob) == new_expected_radius
+end
+
+@testmodule TestBlobInterface3D begin
+    using VEM
+
+    # GIVEN
+
+    mutable struct Blob{D,T} <: VEM.AbstractVortexBlob{D,T}
+        circulation::VEM.SA.SVector{D,T}
+        center::VEM.SA.SVector{D,T}
+        radius::T
+    end
+
+    function Base.zero(::Type{Blob{D,T}}) where {D,T}
+        return Blob(zero(VEM.SA.SVector{D,T}), zero(VEM.SA.SVector{D,T}), zero(T))
+    end
+
+    expected_circulation = VEM.SA.SVector(1.0, 0.0, 0.0)
+    expected_center = VEM.SA.SVector(0.5, 0.5, 0.5)
+    expected_radius = 0.1
+
+    blob = Blob(expected_circulation, expected_center, expected_radius)
+end
+
+@testitem "Get vortex blob type parameters" setup = [TestBlobInterface3D] begin
+    # WHEN
+
+    Dimension = blob_dimension(TestBlobInterface3D.blob)
+    Scalar = blob_scalar(TestBlobInterface3D.blob)
+
+    # THEN
+
+    @test Dimension == 3
+    @test Scalar == Float64
+end
+
+@testitem "Create vortex blob with zero data" setup = [TestBlobInterface3D] begin
+    # WHEN
+
+    zero_blob = zero(TestBlobInterface3D.blob)
+
+    # THEN
+
+    @test blob_circulation(zero_blob) == [0.0, 0.0, 0.0]
+    @test blob_center(zero_blob) == [0.0, 0.0, 0.0]
+    @test blob_radius(zero_blob) == 0.0
+end
+
+@testitem "Get vortex blob data" setup = [TestBlobInterface3D] begin
+    # WHEN
+
+    circulation = blob_circulation(TestBlobInterface3D.blob)
+    center = blob_center(TestBlobInterface3D.blob)
+    radius = blob_radius(TestBlobInterface3D.blob)
+
+    # THEN
+
+    @test circulation == TestBlobInterface3D.expected_circulation
+    @test center == TestBlobInterface3D.expected_center
+    @test radius == TestBlobInterface3D.expected_radius
+end
+
+@testitem "Update vortex blob data" setup = [TestBlobInterface3D] begin
+    # GIVEN
+
+    new_expected_circulation = VEM.SA.SVector(2.0, 0.0, 0.0)
+    new_expected_center = typeof(TestBlobInterface3D.expected_center)(0.6, 0.6, 0.6)
+    new_expected_radius = 0.2
+
+    # WHEN
+
+    blob_circulation!(TestBlobInterface3D.blob, new_expected_circulation)
+    blob_center!(TestBlobInterface3D.blob, new_expected_center)
+    blob_radius!(TestBlobInterface3D.blob, new_expected_radius)
+
+    # THEN
+
+    @test blob_circulation(TestBlobInterface3D.blob) == new_expected_circulation
+    @test blob_center(TestBlobInterface3D.blob) == new_expected_center
+    @test blob_radius(TestBlobInterface3D.blob) == new_expected_radius
+end

--- a/test/blob/cartesian_mesh.jl
+++ b/test/blob/cartesian_mesh.jl
@@ -4,7 +4,7 @@
     mesh = CartesianMesh((5, 5), 0.1)
 
     expected_dimension = 2
-    expected_scalar = Float
+    expected_scalar = Float64
     expected_cells_per_axis = (5, 5)
     expected_nodes_per_axis = (6, 6)
     expected_node_spacing = 0.1

--- a/test/blob/cartesian_mesh.jl
+++ b/test/blob/cartesian_mesh.jl
@@ -1,4 +1,4 @@
-@testsnippet TestCartesianMesh begin
+@testsnippet TestCartesianMesh2D2D begin
     # GIVEN
 
     mesh = CartesianMesh((5, 5), 0.1)
@@ -8,13 +8,14 @@
     expected_cells_per_axis = (5, 5)
     expected_nodes_per_axis = (6, 6)
     expected_node_spacing = 0.1
+    expected_mesh_bounds = ((0.0, 0.5), (0.0, 0.5))
 
     expected_mesh_nodes = [
         VEM.SA.SVector{expected_dimension,expected_scalar}(x, y) for x in 0:0.1:0.5, y in 0:0.1:0.5
     ]
 end
 
-@testitem "Get CartesianMesh dimension (2D)" setup = [TestCartesianMesh] begin
+@testitem "Get 2D Cartesian mesh dimension" setup = [TestCartesianMesh2D] begin
     # WHEN
 
     dimension = mesh_dimension(mesh)
@@ -24,7 +25,7 @@ end
     @test dimension == expected_dimension
 end
 
-@testitem "Get CartesianMesh scalar" setup = [TestCartesianMesh] begin
+@testitem "Get 2D Cartesian mesh scalar" setup = [TestCartesianMesh2D] begin
     # WHEN
 
     scalar = mesh_scalar(mesh)
@@ -34,7 +35,7 @@ end
     @test scalar == expected_scalar
 end
 
-@testitem "Get CartesianMesh cells per axis" setup = [TestCartesianMesh] begin
+@testitem "Get 2D Cartesian mesh cells per axis" setup = [TestCartesianMesh2D] begin
     # WHEN
 
     number_per_axis = cells_per_axis(mesh)
@@ -44,7 +45,7 @@ end
     @test number_per_axis == expected_cells_per_axis
 end
 
-@testitem "Get CartesianMesh nodes per axis" setup = [TestCartesianMesh] begin
+@testitem "Get 2D Cartesian mesh nodes per axis" setup = [TestCartesianMesh2D] begin
     # WHEN
 
     number_per_axis = nodes_per_axis(mesh)
@@ -54,7 +55,7 @@ end
     @test number_per_axis == expected_nodes_per_axis
 end
 
-@testitem "Get CartesianMesh node spacing" setup = [TestCartesianMesh] begin
+@testitem "Get 2D Cartesian mesh node spacing" setup = [TestCartesianMesh2D] begin
     # WHEN
 
     spacing = node_spacing(mesh)
@@ -64,7 +65,105 @@ end
     @test spacing == expected_node_spacing
 end
 
-@testitem "Get CartesianMesh nodes" setup = [TestCartesianMesh] begin
+@testitem "Get 2D Cartesian mesh bounds" setup = [TestCartesianMesh2D] begin
+    # WHEN
+
+    bounds = mesh_bounds(mesh)
+
+    # THEN
+
+    @test bounds == expected_mesh_bounds
+end
+
+@testitem "Get 2D Cartesian mesh nodes" setup = [TestCartesianMesh2D] begin
+    # WHEN
+
+    nodes = mesh_nodes(mesh)
+
+    # THEN
+
+    @test isapprox(nodes, expected_mesh_nodes)
+end
+
+@testsnippet TestCartesianMesh3D begin
+    # GIVEN
+
+    mesh = CartesianMesh((5, 5, 5), 0.1)
+
+    expected_dimension = 3
+    expected_scalar = Float64
+    expected_cells_per_axis = (5, 5, 5)
+    expected_nodes_per_axis = (6, 6, 6)
+    expected_node_spacing = 0.1
+    expected_mesh_bounds = ((0.0, 0.5), (0.0, 0.5), (0.0, 0.5))
+
+    expected_mesh_nodes = [
+        VEM.SA.SVector{expected_dimension,expected_scalar}(x, y, z) for x in 0:0.1:0.5,
+        y in 0:0.1:0.5, z in 0:0.1:0.5
+    ]
+end
+
+@testitem "Get 3D Cartesian mesh dimension" setup = [TestCartesianMesh3D] begin
+    # WHEN
+
+    dimension = mesh_dimension(mesh)
+
+    # THEN
+
+    @test dimension == expected_dimension
+end
+
+@testitem "Get 3D Cartesian mesh scalar" setup = [TestCartesianMesh3D] begin
+    # WHEN
+
+    scalar = mesh_scalar(mesh)
+
+    # THEN
+
+    @test scalar == expected_scalar
+end
+
+@testitem "Get 3D Cartesian mesh cells per axis" setup = [TestCartesianMesh3D] begin
+    # WHEN
+
+    number_per_axis = cells_per_axis(mesh)
+
+    # THEN
+
+    @test number_per_axis == expected_cells_per_axis
+end
+
+@testitem "Get 3D Cartesian mesh nodes per axis" setup = [TestCartesianMesh3D] begin
+    # WHEN
+
+    number_per_axis = nodes_per_axis(mesh)
+
+    # THEN
+
+    @test number_per_axis == expected_nodes_per_axis
+end
+
+@testitem "Get 3D Cartesian mesh node spacing" setup = [TestCartesianMesh3D] begin
+    # WHEN
+
+    spacing = node_spacing(mesh)
+
+    # THEN
+
+    @test spacing == expected_node_spacing
+end
+
+@testitem "Get 3D Cartesian mesh bounds" setup = [TestCartesianMesh3D] begin
+    # WHEN
+
+    bounds = mesh_bounds(mesh)
+
+    # THEN
+
+    @test bounds == expected_mesh_bounds
+end
+
+@testitem "Get 3D Cartesian mesh nodes" setup = [TestCartesianMesh3D] begin
     # WHEN
 
     nodes = mesh_nodes(mesh)

--- a/test/blob/cartesian_mesh.jl
+++ b/test/blob/cartesian_mesh.jl
@@ -1,0 +1,75 @@
+@testsnippet TestCartesianMesh begin
+    # GIVEN
+
+    mesh = CartesianMesh((5, 5), 0.1)
+
+    expected_dimension = 2
+    expected_scalar = Float
+    expected_cells_per_axis = (5, 5)
+    expected_nodes_per_axis = (6, 6)
+    expected_node_spacing = 0.1
+
+    expected_mesh_nodes = [
+        VEM.SA.SVector{expected_dimension,expected_scalar}(x, y) for x in 0:0.1:0.5, y in 0:0.1:0.5
+    ]
+end
+
+@testitem "Get CartesianMesh dimension (2D)" setup = [TestCartesianMesh] begin
+    # WHEN
+
+    dimension = mesh_dimension(mesh)
+
+    # THEN
+
+    @test dimension == expected_dimension
+end
+
+@testitem "Get CartesianMesh scalar" setup = [TestCartesianMesh] begin
+    # WHEN
+
+    scalar = mesh_scalar(mesh)
+
+    # THEN
+
+    @test scalar == expected_scalar
+end
+
+@testitem "Get CartesianMesh cells per axis" setup = [TestCartesianMesh] begin
+    # WHEN
+
+    number_per_axis = cells_per_axis(mesh)
+
+    # THEN
+
+    @test number_per_axis == expected_cells_per_axis
+end
+
+@testitem "Get CartesianMesh nodes per axis" setup = [TestCartesianMesh] begin
+    # WHEN
+
+    number_per_axis = nodes_per_axis(mesh)
+
+    # THEN
+
+    @test number_per_axis == expected_nodes_per_axis
+end
+
+@testitem "Get CartesianMesh node spacing" setup = [TestCartesianMesh] begin
+    # WHEN
+
+    spacing = node_spacing(mesh)
+
+    # THEN
+
+    @test spacing == expected_node_spacing
+end
+
+@testitem "Get CartesianMesh nodes" setup = [TestCartesianMesh] begin
+    # WHEN
+
+    nodes = mesh_nodes(mesh)
+
+    # THEN
+
+    @test isapprox(nodes, expected_mesh_nodes)
+end

--- a/test/blob/cartesian_mesh.jl
+++ b/test/blob/cartesian_mesh.jl
@@ -1,4 +1,4 @@
-@testsnippet TestCartesianMesh2D2D begin
+@testsnippet TestCartesianMesh2D begin
     # GIVEN
 
     mesh = CartesianMesh((5, 5), 0.1)

--- a/test/blob/field_interface.jl
+++ b/test/blob/field_interface.jl
@@ -1,0 +1,75 @@
+@testmodule TestFieldInterface2D begin
+    using VEM
+
+    # GIVEN
+
+    struct Blob <: VEM.AbstractVortexBlob{2,Float64}
+        circulation::Float64
+        center::VEM.SA.SVector{2,Float64}
+        radius::Float64
+    end
+
+    blob = Blob(1.0, [0.5, 0.5], 0.1)
+
+    expected_velocity_type = VEM.SA.SVector{2,Float64}
+    expected_vorticity_type = Float64
+end
+
+@testitem "2D velocity field value is a 2D SVector" setup = [TestFieldInterface2D] begin
+    # WHEN
+
+    type = field_scalar(VelocityField(), TestFieldInterface2D.blob)
+
+    # THEN
+
+    @test type == TestFieldInterface2D.expected_velocity_type
+end
+
+@testitem "2D vorticity field value is a float" setup = [TestFieldInterface2D] begin
+    # WHEN
+
+    type = field_scalar(VorticityField(), TestFieldInterface2D.blob)
+
+    # THEN
+
+    @test type == TestFieldInterface2D.expected_vorticity_type
+end
+
+@testmodule TestFieldInterface3D begin
+    using VEM
+
+    # GIVEN
+
+    struct Blob <: VEM.AbstractVortexBlob{3,Float64}
+        circulation::VEM.SA.SVector{3,Float64}
+        center::VEM.SA.SVector{3,Float64}
+        radius::Float64
+    end
+
+    blob = Blob(
+        VEM.SA.SVector{3,Float64}(1.0, 0.0, 0.0), VEM.SA.SVector{3,Float64}(0.5, 0.5, 0.5), 0.1
+    )
+
+    expected_velocity_type = VEM.SA.SVector{3,Float64}
+    expected_vorticity_type = VEM.SA.SVector{3,Float64}
+end
+
+@testitem "3D velocity field value is a 3D SVector" setup = [TestFieldInterface3D] begin
+    # WHEN
+
+    type = field_scalar(VelocityField(), TestFieldInterface3D.blob)
+
+    # THEN
+
+    @test type == TestFieldInterface3D.expected_velocity_type
+end
+
+@testitem "3D vorticity field value is a 3D SVector" setup = [TestFieldInterface3D] begin
+    # WHEN
+
+    type = field_scalar(VorticityField(), TestFieldInterface3D.blob)
+
+    # THEN
+
+    @test type == TestFieldInterface3D.expected_vorticity_type
+end

--- a/test/blob/gaussian_blob.jl
+++ b/test/blob/gaussian_blob.jl
@@ -1,4 +1,16 @@
-@testitem "Create blob with center::Tuple (2D)" begin
+@testitem "Create a 2D Gaussian vortex blob with zero data" begin
+    # WHEN
+
+    blob = zero(GaussianVortexBlob{2,Float64})
+
+    # THEN
+
+    @test blob_circulation(blob) == 0.0
+    @test blob_center(blob) == [0.0, 0.0]
+    @test blob_radius(blob) == 0.0
+end
+
+@testitem "Create a 2D Gaussian vortex blob with center::Tuple" begin
     # GIVEN
 
     center = (0.5, 0.5)
@@ -11,7 +23,7 @@
     end
 end
 
-@testitem "Create blob with center::Vector (2D)" begin
+@testitem "Create a 2D Gaussian vortex blob with center::Vector" begin
     # GIVEN
 
     center = [0.5, 0.5]
@@ -24,7 +36,7 @@ end
     end
 end
 
-@testitem "Create blob with center::SVector (2D)" begin
+@testitem "Create a 2D Gaussian vortex blob with center::SVector" begin
     # GIVEN
 
     center = VEM.SA.SVector(0.5, 0.5)
@@ -37,7 +49,7 @@ end
     end
 end
 
-@testitem "Cannot create blob with mixed floating-point types (2D)" begin
+@testitem "Cannot create a 2D Gaussian vortex blob with mixed floating-point types" begin
     # GIVEN
 
     circulation = Float64(1)
@@ -49,7 +61,7 @@ end
     @test_throws MethodError blob = GaussianVortexBlob(circulation, center, radius)
 end
 
-@testitem "Cannot create blob with scalar circulation and 3D position" begin
+@testitem "Cannot create a 2D Gaussian vortex blob with scalar circulation and 3D position" begin
     # GIVEN
 
     circulation = 0.23024673335450663
@@ -61,7 +73,7 @@ end
     @test_throws ArgumentError blob = GaussianVortexBlob(circulation, center, radius)
 end
 
-@testitem "Cannot create blob with 3D circulation and 2D position" begin
+@testitem "Cannot create a 2D Gaussian vortex blob with 3D circulation and 2D position" begin
     # GIVEN
 
     circulation = [0.11337262536359693, 0.28145956014569606, 0.4192211746213216]
@@ -85,7 +97,7 @@ end
     blob = GaussianVortexBlob(expected_circulation, expected_center, expected_radius)
 end
 
-@testitem "Get vortex blob dimension (2D)" setup = [TestGaussianBlob] begin
+@testitem "Get dimension of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     # WHEN
@@ -97,7 +109,7 @@ end
     @test dimension == expected_dimension
 end
 
-@testitem "Get vortex blob scalar (2D)" setup = [TestGaussianBlob] begin
+@testitem "Get scalar of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     # WHEN
@@ -109,7 +121,7 @@ end
     @test scalar == expected_scalar
 end
 
-@testitem "Get vortex blob circulation (2D)" setup = [TestGaussianBlob] begin
+@testitem "Get circulation of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     # WHEN
@@ -121,7 +133,7 @@ end
     @test circulation == expected_circulation
 end
 
-@testitem "Update vortex blob circulation (2D)" setup = [TestGaussianBlob] begin
+@testitem "Update circulation of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     new_circulation = 1.0
@@ -135,7 +147,7 @@ end
     @test blob_circulation(blob) == new_circulation
 end
 
-@testitem "Get vortex blob center (2D)" setup = [TestGaussianBlob] begin
+@testitem "Get center of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     # WHEN
@@ -147,7 +159,7 @@ end
     @test center == expected_center
 end
 
-@testitem "Update vortex blob center (2D)" setup = [TestGaussianBlob] begin
+@testitem "Update center of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     new_center = (0.5, 0.5)
@@ -161,7 +173,7 @@ end
     @test all(blob_center(blob) .== new_center)
 end
 
-@testitem "Get vortex blob radius (2D)" setup = [TestGaussianBlob] begin
+@testitem "Get radius of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     # WHEN
@@ -173,7 +185,7 @@ end
     @test radius == expected_radius
 end
 
-@testitem "Update vortex blob radius (2D)" setup = [TestGaussianBlob] begin
+@testitem "Update radius of a 2D Gaussian vortex blob" setup = [TestGaussianBlob] begin
     # GIVEN
 
     new_radius = 1.0
@@ -341,7 +353,7 @@ end
     @test isapprox(VEM.LA.norm(velocity), expected_velocity_magnitude; rtol=1e-15)
 end
 
-@testitem "Induced velocity type is the expected type" begin
+@testitem "Induced velocity type is the expected type (2D)" begin
     T = (Float16, Float32, Float64, BigFloat)
 
     for T1 in T
@@ -418,7 +430,7 @@ end
     @test isapprox(vorticity_2 / vorticity_1, expected_ratio; rtol=1e-12)
 end
 
-@testitem "Induced vorticity type is the expected type" begin
+@testitem "Induced vorticity type is the expected type (2D)" begin
     T = (Float16, Float32, Float64, BigFloat)
 
     for T1 in T
@@ -436,7 +448,7 @@ end
     end
 end
 
-@testitem "Induced velocity is consistent with induced vorticity" setup = [TestGaussianBlob] begin
+@testitem "Induced velocity is consistent with induced vorticity (2D)" setup = [TestGaussianBlob] begin
     # GIVEN
 
     target = blob_center(blob) + [0.7903753220899068, 0.20269405341897373]

--- a/test/blob/redistribution.jl
+++ b/test/blob/redistribution.jl
@@ -1,0 +1,236 @@
+@testsnippet TestRedistribution begin
+    # GIVEN
+
+    struct Simple <: VEM.AbstractRedistributionKernel end
+    VEM.redistribution_weight(::Simple, r) = r <= 2 ? 1.0 : 0.0
+    VEM.support_radius(::Simple) = 2
+end
+
+@testsnippet TestRedistributionPerfectOverlap begin
+    # GIVEN
+
+    mesh = CartesianMesh((5, 5), 0.2)
+    kernel = Simple()
+
+    circulation = 0.6530376028766707
+    radius = node_spacing(mesh)
+
+    absolute_tolerance = 1e-15
+end
+
+@testitem "Blob outside of redistribution mesh throws ArgumentError" setup = [
+    TestRedistribution, TestRedistributionPerfectOverlap
+] begin
+    # GIVEN
+
+    centers = [[-1.0, 0.5], [1.5, 0.5], [0.5, -1.0], [0.5, 1.5]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        @test_throws ArgumentError redistribute(blobs, mesh, kernel)
+    end
+end
+
+@testitem "Number of redistributed blobs equals number of nodes in mesh" setup = [
+    TestRedistribution, TestRedistributionPerfectOverlap
+] begin
+    # GIVEN
+
+    center = [0.5, 0.5]
+
+    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+
+    # WHEN
+
+    redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+    # THEN
+
+    @test size(redistributed_blobs) == nodes_per_axis(mesh)
+end
+
+@testitem "Number of non-zero redistributed blobs equals 16 for source blob far from mesh boundaries" setup = [
+    TestRedistribution, TestRedistributionPerfectOverlap
+] begin
+    # GIVEN
+
+    center = [0.5, 0.5]
+
+    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+
+    # WHEN
+
+    redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+    # THEN
+
+    @test sum(x -> x != 0, redistributed_blobs) == 16
+end
+
+@testitem "Number of non-zero redistributed blobs equals 12 for source blob near a mesh edge" setup = [
+    TestRedistribution, TestRedistributionPerfectOverlap
+] begin
+    # GIVEN
+
+    centers = [[0.1, 0.5], [0.9, 0.5], [0.5, 0.1], [0.5, 0.9]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+        @test sum(x -> x != 0, redistributed_blobs) == 12
+    end
+end
+
+@testitem "Number of non-zero redistributed blobs equals 9 for source blob near a mesh corner" setup = [
+    TestRedistribution, TestRedistributionPerfectOverlap
+] begin
+    # GIVEN
+
+    centers = [[0.1, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.9]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+        @test sum(x -> x != 0, redistributed_blobs) == 9
+    end
+end
+
+@testsnippet TestRedistributionOverResolved begin
+    # GIVEN
+
+    mesh = CartesianMesh((7, 7), 1 / 7)
+    kernel = Simple()
+
+    overlap_ratio = 1.5
+
+    circulation = 0.6530376028766707
+    radius = overlap_ratio * node_spacing(mesh)
+
+    absolute_tolerance = 1e-15
+end
+
+@testitem "Number of non-zero redistributed blobs equals 36 for source blob far from mesh boundaries" setup = [
+    TestRedistribution, TestRedistributionOverResolved
+] begin
+    # GIVEN
+
+    center = [0.5, 0.5]
+
+    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+
+    # WHEN
+
+    redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+    # THEN
+
+    @test sum(x -> x != 0, redistributed_blobs) == 36
+end
+
+@testitem "Number of non-zero redistributed blobs equals 24 for source blob near a mesh edge" setup = [
+    TestRedistribution, TestRedistributionOverResolved
+] begin
+    # GIVEN
+
+    centers = [[1 / 14, 0.5], [13 / 14, 0.5], [0.5, 1 / 14], [0.5, 13 / 14]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+        @test sum(x -> x != 0, redistributed_blobs) == 24
+    end
+end
+
+@testitem "Number of non-zero redistributed blobs equals 16 for source blob near a mesh corner" setup = [
+    TestRedistribution, TestRedistributionOverResolved
+] begin
+    # GIVEN
+
+    centers = [[0.1, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.9]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+        @test sum(x -> x != 0, redistributed_blobs) == 16
+    end
+end
+
+@testsnippet TestRedistributionUnderResolved begin
+    # GIVEN
+
+    mesh = CartesianMesh((7, 7), 1 / 7)
+    kernel = Simple()
+
+    overlap_ratio = 0.5
+
+    circulation = 0.6530376028766707
+    radius = overlap_ratio * node_spacing(mesh)
+
+    absolute_tolerance = 1e-15
+end
+
+@testitem "Number of non-zero redistributed blobs equals 4 for source blob far from mesh boundaries" setup = [
+    TestRedistribution, TestRedistributionUnderResolved
+] begin
+    # GIVEN
+
+    center = [0.5, 0.5]
+
+    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+
+    # WHEN
+
+    redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+    # THEN
+
+    @test sum(x -> x != 0, redistributed_blobs) == 4
+end
+
+@testitem "Number of non-zero redistributed blobs equals 4 for source blob near a mesh edge" setup = [
+    TestRedistribution, TestRedistributionUnderResolved
+] begin
+    # GIVEN
+
+    centers = [[1 / 14, 0.5], [13 / 14, 0.5], [0.5, 1 / 14], [0.5, 13 / 14]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+        @test sum(x -> x != 0, redistributed_blobs) == 4
+    end
+end
+
+@testitem "Number of non-zero redistributed blobs equals 4 for source blob near a mesh corner" setup = [
+    TestRedistribution, TestRedistributionUnderResolved
+] begin
+    # GIVEN
+
+    centers = [[0.1, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.9]]
+
+    # WHEN / THEN
+
+    for center in centers
+        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        redistributed_blobs = redistribute(blobs, mesh, kernel)
+
+        @test sum(x -> x != 0, redistributed_blobs) == 4
+    end
+end

--- a/test/blob/redistribution.jl
+++ b/test/blob/redistribution.jl
@@ -28,7 +28,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         @test_throws ArgumentError interpolate_circulation(blobs, mesh, kernel)
     end
 end
@@ -40,7 +40,7 @@ end
 
     center = [0.5, 0.5]
 
-    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+    blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
 
     # WHEN
 
@@ -58,7 +58,7 @@ end
 
     center = [0.5, 0.5]
 
-    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+    blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
 
     # WHEN
 
@@ -79,7 +79,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 12
@@ -96,7 +96,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 9
@@ -124,7 +124,7 @@ end
 
     center = [0.5, 0.5]
 
-    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+    blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
 
     # WHEN
 
@@ -145,7 +145,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 24
@@ -162,7 +162,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 16
@@ -190,7 +190,7 @@ end
 
     center = [0.5, 0.5]
 
-    blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+    blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
 
     # WHEN
 
@@ -211,7 +211,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 4
@@ -228,7 +228,7 @@ end
     # WHEN / THEN
 
     for center in centers
-        blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
+        blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
         redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 4

--- a/test/blob/redistribution.jl
+++ b/test/blob/redistribution.jl
@@ -29,7 +29,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        @test_throws ArgumentError redistribute(blobs, mesh, kernel)
+        @test_throws ArgumentError interpolate_circulation(blobs, mesh, kernel)
     end
 end
 
@@ -44,7 +44,7 @@ end
 
     # WHEN
 
-    redistributed_blobs = redistribute(blobs, mesh, kernel)
+    redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
     # THEN
 
@@ -62,7 +62,7 @@ end
 
     # WHEN
 
-    redistributed_blobs = redistribute(blobs, mesh, kernel)
+    redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
     # THEN
 
@@ -80,7 +80,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        redistributed_blobs = redistribute(blobs, mesh, kernel)
+        redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 12
     end
@@ -97,7 +97,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        redistributed_blobs = redistribute(blobs, mesh, kernel)
+        redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 9
     end
@@ -128,7 +128,7 @@ end
 
     # WHEN
 
-    redistributed_blobs = redistribute(blobs, mesh, kernel)
+    redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
     # THEN
 
@@ -146,7 +146,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        redistributed_blobs = redistribute(blobs, mesh, kernel)
+        redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 24
     end
@@ -163,7 +163,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        redistributed_blobs = redistribute(blobs, mesh, kernel)
+        redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 16
     end
@@ -194,7 +194,7 @@ end
 
     # WHEN
 
-    redistributed_blobs = redistribute(blobs, mesh, kernel)
+    redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
     # THEN
 
@@ -212,7 +212,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        redistributed_blobs = redistribute(blobs, mesh, kernel)
+        redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 4
     end
@@ -229,7 +229,7 @@ end
 
     for center in centers
         blobs = [GaussianVortexBlob{2,Float}(circulation, center, radius)]
-        redistributed_blobs = redistribute(blobs, mesh, kernel)
+        redistributed_blobs = interpolate_circulation(blobs, mesh, kernel)
 
         @test sum(x -> x != 0, redistributed_blobs) == 4
     end

--- a/test/blob/redistribution.jl
+++ b/test/blob/redistribution.jl
@@ -18,6 +18,28 @@ end
     absolute_tolerance = 1e-15
 end
 
+@testitem "Redistribute blobs" setup = [TestRedistribution, TestRedistributionPerfectOverlap] begin
+    # GIVEN
+
+    center = [0.5, 0.5]
+
+    blobs = [GaussianVortexBlob{2,Float64}(circulation, center, radius)]
+
+    # WHEN
+
+    redistributed_blobs = redistribution(blobs, mesh, kernel)
+
+    # THEN
+
+    @test eltype(redistributed_blobs) == eltype(blobs)
+    @test size(redistributed_blobs) == nodes_per_axis(mesh)
+    @test blob_radius(redistributed_blobs[1]) == blob_radius(blobs[1]) == node_spacing(mesh)
+
+    for (blob, node) in zip(redistributed_blobs, mesh_nodes(mesh))
+        @test isapprox(blob_center(blob), node)
+    end
+end
+
 @testitem "Blob outside of redistribution mesh throws ArgumentError" setup = [
     TestRedistribution, TestRedistributionPerfectOverlap
 ] begin

--- a/test/blob/redistribution_kernel.jl
+++ b/test/blob/redistribution_kernel.jl
@@ -3,24 +3,12 @@
 
     kernel = M4Prime()
     expected_support_radius = 2
-end
-
-@testitem "Get M4' support radius" setup = [TestM4PrimeKernel] begin
-    # WHEN
-
-    radius = support_radius(kernel)
-
-    # THEN
-
-    @test radius == expected_support_radius
-end
-
-@testitem "Compute M4' redistribution weight" setup = [TestM4PrimeKernel] begin
-    # GIVEN
 
     distances = 0.0:0.5:2.5
     expected_weights = [1.0, 0.5625, 0.0, -0.0625, 0.0, 0.0]
+end
 
+@testitem "Compute M4' redistribution weight" setup = [TestM4PrimeKernel] begin
     # WHEN
 
     weights = [redistribution_weight(kernel, x) for x in distances]
@@ -31,10 +19,6 @@ end
 end
 
 @testitem "M4' redistribution kernel is an even function" setup = [TestM4PrimeKernel] begin
-    # GIVEN
-
-    distances = 0.0:0.5:2.5
-
     # WHEN / THEN
 
     for distance in distances
@@ -42,4 +26,14 @@ end
             redistribution_weight(kernel, distance), redistribution_weight(kernel, -distance)
         )
     end
+end
+
+@testitem "Get M4' support radius" setup = [TestM4PrimeKernel] begin
+    # WHEN
+
+    radius = support_radius(kernel)
+
+    # THEN
+
+    @test radius == expected_support_radius
 end

--- a/test/blob/redistribution_kernel.jl
+++ b/test/blob/redistribution_kernel.jl
@@ -1,0 +1,31 @@
+@testsnippet TestM4PrimeKernel begin
+    # GIVEN
+
+    kernel = M4Prime()
+    expected_support_radius = 2
+end
+
+@testitem "Get M4' support radius" setup = [TestM4PrimeKernel] begin
+    # WHEN
+
+    radius = support_radius(kernel)
+
+    # THEN
+
+    @test radius == expected_support_radius
+end
+
+@testitem "Compute M4' redistribution weight" setup = [TestM4PrimeKernel] begin
+    # GIVEN
+
+    distances = 0.0:0.5:2.5
+    expected_weights = [1.0, 0.5625, 0.0, -0.0625, 0.0, 0.0]
+
+    # WHEN
+
+    weights = [redistribution_weight(kernel, x) for x in distances]
+
+    # THEN
+
+    @test isapprox(weights, expected_weights)
+end

--- a/test/blob/redistribution_kernel.jl
+++ b/test/blob/redistribution_kernel.jl
@@ -29,3 +29,17 @@ end
 
     @test isapprox(weights, expected_weights)
 end
+
+@testitem "M4' redistribution kernel is an even function" setup = [TestM4PrimeKernel] begin
+    # GIVEN
+
+    distances = 0.0:0.5:2.5
+
+    # WHEN / THEN
+
+    for distance in distances
+        @test isapprox(
+            redistribution_weight(kernel, distance), redistribution_weight(kernel, -distance)
+        )
+    end
+end


### PR DESCRIPTION
This PR adds the feature to redistribute existing vortex blobs onto the nodes of a Cartesian mesh using a user-specified redistribution kernel that derives from `AbstractRedistributionKernel`. This PR provides the M4' kernel: `M4Prime`.