### PR TITLE
Add population control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Diffusion of blob circulations using explicit multi-stage time schemes and a finite-difference spatial discretization: `diffusion!`. ([#29])
 
+- Population control of vortex blobs by means of pruning based on circulation magnitude thresholding: `population_control!`. ([#30])
+
 ### Changed
 
 -

--- a/src/VEM.jl
+++ b/src/VEM.jl
@@ -65,6 +65,9 @@ export interpolate_circulation
 include("blob/diffusion.jl")
 export diffusion!
 
+include("blob/population_control.jl")
+export population_control!
+
 include("precompile.jl")
 
 end

--- a/src/blob/population_control.jl
+++ b/src/blob/population_control.jl
@@ -1,0 +1,41 @@
+"""
+    population_control!(blobs, tolerance)
+
+Prune vortex blobs based on their circulation magnitude to maintain a manageable population size.
+The pruning procedure ensures that the sum of circulation magnitude removed is smaller than the specified tolerance multiplied by the sum of all circulation magnitudes.
+
+# Arguments
+- `blobs`: A collection of vortex blobs.
+- `tolerance`: A scalar value that determines a relative threshold for pruning.
+
+# Returns
+- `removed_circulation`: The total circulation removed due to pruning.
+"""
+function population_control!(blobs, tolerance)
+    removed_circulation = zero(blob_scalar(first(blobs)))
+
+    zero_indices = findall(x -> blob_circulation(x) == 0, blobs)
+    deleteat!(blobs, zero_indices)
+
+    if isempty(blobs)
+        return removed_circulation
+    end
+
+    circulation_magnitudes = map(x -> LA.norm(blob_circulation(x)), blobs)
+    circulation_magnitude_sum = sum(circulation_magnitudes)
+
+    accumulation = zero(circulation_magnitude_sum)
+    threshold = tolerance * circulation_magnitude_sum
+
+    for circulation_magnitude in sort(circulation_magnitudes)
+        if accumulation + circulation_magnitude > threshold
+            remove_indices = findall(x -> x < circulation_magnitude, circulation_magnitudes)
+            removed_circulation = sum(index -> blob_circulation(blobs[index]), remove_indices)
+            deleteat!(blobs, remove_indices)
+            break
+        end
+        accumulation += circulation_magnitude
+    end
+
+    return removed_circulation
+end

--- a/test/blob/population_control.jl
+++ b/test/blob/population_control.jl
@@ -1,0 +1,83 @@
+@testsnippet TestPopulationControl begin
+    using VEM
+
+    struct Blob <: AbstractVortexBlob{2,Float64}
+        circulation::Float64
+    end
+end
+
+@testitem "Population control with positive blobs" setup = [TestPopulationControl] begin
+    # GIVEN
+
+    blobs = [Blob(i) for i in 1:10]
+    tolerance = 0.5
+
+    expected_remaining_blob = 4
+    expected_removed_circulation = 21.0
+
+    # WHEN
+
+    removed_circulation = population_control!(blobs, tolerance)
+
+    #THEN
+
+    @test length(blobs) == expected_remaining_blob
+    @test removed_circulation ≈ expected_removed_circulation
+end
+
+@testitem "Population control with negative blobs" setup = [TestPopulationControl] begin
+    # GIVEN
+
+    blobs = [Blob(-i) for i in 1:10]
+    tolerance = 0.5
+
+    expected_remaining_blob = 4
+    expected_removed_circulation = -21.0
+
+    # WHEN
+
+    removed_circulation = population_control!(blobs, tolerance)
+
+    #THEN
+
+    @test length(blobs) == expected_remaining_blob
+    @test removed_circulation ≈ expected_removed_circulation
+end
+
+@testitem "Population control with mixed blobs" setup = [TestPopulationControl] begin
+    # GIVEN
+
+    blobs = [Blob((-1)^i * i) for i in 1:10]
+    tolerance = 0.5
+
+    expected_remaining_blob = 4
+    expected_removed_circulation = 3.0
+
+    # WHEN
+
+    removed_circulation = population_control!(blobs, tolerance)
+
+    #THEN
+
+    @test length(blobs) == expected_remaining_blob
+    @test removed_circulation ≈ expected_removed_circulation
+end
+
+@testitem "Population control with zero circulation blobs" setup = [TestPopulationControl] begin
+    # GIVEN
+
+    blobs = [Blob(0.0) for i in 1:10]
+    tolerance = 0.5
+
+    expected_remaining_blob = 0
+    expected_removed_circulation = 0.0
+
+    # WHEN
+
+    removed_circulation = population_control!(blobs, tolerance)
+
+    #THEN
+
+    @test length(blobs) == expected_remaining_blob
+    @test removed_circulation ≈ expected_removed_circulation
+end


### PR DESCRIPTION
Add population control algorithm to maintain a manageable number of vortex blobs. The algorithm removes vortex blobs with the lowest circulation magnitude, such that the sum of removed circulation magnitude is smaller than a specified tolerance multiplied by the total sum of circulation magnitude.